### PR TITLE
* beamerthemem.sty(frametitle): \protect the frametitle inside MakeLowercase

### DIFF
--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -201,7 +201,7 @@
 \setbeamertemplate{frametitle}{%
 \nointerlineskip
 \begin{beamercolorbox}[wd=\paperwidth,leftskip=0.3cm,rightskip=0.3cm,ht=2.5ex,dp=1.5ex]{frametitle}
-  \usebeamerfont{frametitle}\MakeLowercase{\insertframetitle}%
+  \usebeamerfont{frametitle}\MakeLowercase{\protect\insertframetitle}%
 \end{beamercolorbox}%
 \if@useTitleProgressBar
   \vspace{-.5em}


### PR DESCRIPTION
Without the \protect, we cannot use \cite, \ref or similar stuff in frametitle.
