### PR TITLE
Simple fix to ensure colour of footnote mark matches the surrounding environment.

### DIFF
--- a/beamercolorthememetropolis.sty
+++ b/beamercolorthememetropolis.sty
@@ -37,6 +37,7 @@
 \setbeamercolor{alerted text}{fg=mLightBrown}
 
 \setbeamercolor{footnote}{fg=mDarkTeal!50}
+\setbeamercolor{footnote mark}{fg=.}
 \setbeamercolor{page number in head/foot}{fg=mDarkTeal}
 
 \mode


### PR DESCRIPTION
Awesome theme!

When using `\plain` the footnote marks were a bit too dark. This should fix it.

Before:
![screen shot 2015-01-23 at 1 18 37 pm](https://cloud.githubusercontent.com/assets/891877/5874797/f6f17216-a305-11e4-9631-61496cd41c70.png)

After: 
![screen shot 2015-01-23 at 1 45 09 pm](https://cloud.githubusercontent.com/assets/891877/5874809/116d5b3c-a306-11e4-9771-55d05167cd48.png)
