### PR TITLE
Add three options: usesmallcapitalsintitle, usesectionslide and nototals...

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ make content more centered on the frame. If using more content per
 slide, this can be turned off at the package-level by passing the
 `nooffset` option.
 
+With option `nosectionslide`, no dedicated slide is produced when a new section
+starts. By default when using the `\section` command, a slide is created with
+just the title on it.
+
+The `nosmallcapitals` option supresses the usage of small capitals on
+title page, frame titles and dedicated section slides.
+
+Option `usetotalslideindicator` creates slide numbering in lower right corner
+in following format: #current/#total. By default, just current page number is
+printed.
 
 #### Commands
 

--- a/beamerfontthememetropolis.sty
+++ b/beamerfontthememetropolis.sty
@@ -32,7 +32,7 @@
 \setbeamerfont{block title alerted}{family=\Book,size=\normalsize}
 
 \setbeamerfont{subtitle}{family=\Light, size=\fontsize{12}{14}}
-\setbeamerfont{frametitle}{family=\Book, series=\scshape, size=\large}
+\setbeamerfont{frametitle}{family=\Book, size=\large}
 
 \setbeamerfont{caption}{size=\small}
 \setbeamerfont{caption name}{family=\Book}

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -13,9 +13,15 @@
 
 \newif\if@useTitleProgressBar
 \newif\if@protectFrameTitle
+\newif\if@useSmallCapitalsInTitle
+\newif\if@useSectionSlide
+\newif\if@noTotalSlides
 
 \@useTitleProgressBarfalse
 \@protectFrameTitlefalse
+\@useSmallCapitalsInTitlefalse
+\@useSectionSlidefalse
+\@noTotalSlidesfalse
 
 \newlength{\@mtheme@voffset}
 \setlength{\@mtheme@voffset}{2em}
@@ -30,6 +36,10 @@
 \DeclareOptionBeamer*{%
   \PackageWarning{beamerthemem}{Unknown option `\CurrentOption'}%
 }
+
+\DeclareOptionBeamer{usesmallcapitalsintitle}{\@useSmallCapitalsInTitletrue}
+\DeclareOptionBeamer{usesectionslide}{\@useSectionSlidetrue}
+\DeclareOptionBeamer{nototalslides}{\@noTotalSlidestrue}
 
 \ProcessOptionsBeamer
 
@@ -76,7 +86,7 @@
     \vfill
     \ifx\inserttitle\@empty%
     \else%
-    {\raggedright\linespread{1.0}\usebeamerfont{title}\usebeamercolor[fg]{title}\scshape\MakeLowercase{\inserttitle}\par}%
+    {\raggedright\linespread{1.0}\usebeamerfont{title}\usebeamercolor[fg]{title}\inserttitle\par}%
     \vspace*{0.5em}
     \fi%
     \ifx\insertsubtitle\@empty%
@@ -173,8 +183,11 @@
 
 \newcommand{\insertsectionHEAD}{%
   \expandafter\insertsectionHEADaux\insertsectionhead}
-  \newcommand{\insertsectionHEADaux}[3]{\textsc{\MakeLowercase{#3}}
-}
+\if@useSmallCapitalsInTitle
+\newcommand{\insertsectionHEADaux}[3]{\textsc{\MakeLowercase{#3}}}
+\else
+\newcommand{\insertsectionHEADaux}[3]{#3}
+\fi
 
 \newcommand{\plain}[2][]{%
   \begingroup
@@ -206,6 +219,7 @@
 %{{{ --- Sections ---------------------
 
 % Insert frame with section title at every section start
+\if@useSectionSlide
 \AtBeginSection[]
 {
   \begingroup
@@ -216,6 +230,7 @@
   \end{frame}
   \endgroup
 }
+\fi
 
 %}}}
 %{{{ --- Captions ---------------------
@@ -231,7 +246,11 @@
 {%
 \begin{beamercolorbox}[wd=\textwidth,ht=3ex,dp=3ex,leftskip=0.3cm,rightskip=0.3cm]{structure}%
   \hfill\usebeamerfont{page number in head/foot}%
-  \insertframenumber%
+  \if@noTotalSlides
+  \insertpagenumber%
+  \else
+  \insertpagenumber/\insertpresentationendpage%
+  \fi
 \end{beamercolorbox}%
 }
 
@@ -249,9 +268,9 @@
 \nointerlineskip
 \begin{beamercolorbox}[wd=\paperwidth,leftskip=0.3cm,rightskip=0.3cm,ht=2.5ex,dp=1.5ex]{frametitle}
 \if@protectFrameTitle
-  \usebeamerfont{frametitle}\MakeLowercase{\protect\insertframetitle}%
+  \usebeamerfont{frametitle}\protect\insertframetitle%
 \else
-  \usebeamerfont{frametitle}\MakeLowercase{\insertframetitle}%
+  \usebeamerfont{frametitle}\insertframetitle%
 \fi
 \end{beamercolorbox}%
 \if@useTitleProgressBar

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -13,15 +13,15 @@
 
 \newif\if@useTitleProgressBar
 \newif\if@protectFrameTitle
-\newif\if@useSmallCapitalsInTitle
-\newif\if@useSectionSlide
-\newif\if@noTotalSlides
+\newif\if@noSmallCapitals
+\newif\if@noSectionSlide
+\newif\if@useTotalSlideIndicator
 
 \@useTitleProgressBarfalse
 \@protectFrameTitlefalse
-\@useSmallCapitalsInTitlefalse
-\@useSectionSlidefalse
-\@noTotalSlidesfalse
+\@noSmallCapitalsfalse
+\@noSectionSlidefalse
+\@useTotalSlideIndicatorfalse
 
 \newlength{\@mtheme@voffset}
 \setlength{\@mtheme@voffset}{2em}
@@ -37,9 +37,9 @@
   \PackageWarning{beamerthemem}{Unknown option `\CurrentOption'}%
 }
 
-\DeclareOptionBeamer{usesmallcapitalsintitle}{\@useSmallCapitalsInTitletrue}
-\DeclareOptionBeamer{usesectionslide}{\@useSectionSlidetrue}
-\DeclareOptionBeamer{nototalslides}{\@noTotalSlidestrue}
+\DeclareOptionBeamer{nosmallcapitals}{\@noSmallCapitalstrue}
+\DeclareOptionBeamer{nosectionslide}{\@noSectionSlidetrue}
+\DeclareOptionBeamer{usetotalslideindicator}{\@useTotalSlideIndicatortrue}
 
 \ProcessOptionsBeamer
 
@@ -86,7 +86,11 @@
     \vfill
     \ifx\inserttitle\@empty%
     \else%
+    \if@noSmallCapitals%
     {\raggedright\linespread{1.0}\usebeamerfont{title}\usebeamercolor[fg]{title}\inserttitle\par}%
+    \else%
+    {\raggedright\linespread{1.0}\usebeamerfont{title}\usebeamercolor[fg]{title}\scshape\MakeLowercase{\inserttitle}\par}%
+    \fi%
     \vspace*{0.5em}
     \fi%
     \ifx\insertsubtitle\@empty%
@@ -183,11 +187,12 @@
 
 \newcommand{\insertsectionHEAD}{%
   \expandafter\insertsectionHEADaux\insertsectionhead}
-\if@useSmallCapitalsInTitle
-\newcommand{\insertsectionHEADaux}[3]{\textsc{\MakeLowercase{#3}}}
-\else
-\newcommand{\insertsectionHEADaux}[3]{#3}
-\fi
+
+\if@noSmallCapitals%
+\newcommand{\insertsectionHEADaux}[3]{#3}%
+\else%
+\newcommand{\insertsectionHEADaux}[3]{\textsc{\MakeLowercase{#3}}}%
+\fi%
 
 \newcommand{\plain}[2][]{%
   \begingroup
@@ -219,9 +224,10 @@
 %{{{ --- Sections ---------------------
 
 % Insert frame with section title at every section start
-\if@useSectionSlide
 \AtBeginSection[]
 {
+  \if@noSectionSlide%
+  \else%
   \begingroup
   \setbeamercolor{background canvas}{parent=palette primary}
   \begin{frame}[plain]
@@ -229,8 +235,8 @@
     \progressbar@sectionprogressbar%
   \end{frame}
   \endgroup
+  \fi%
 }
-\fi
 
 %}}}
 %{{{ --- Captions ---------------------
@@ -246,11 +252,11 @@
 {%
 \begin{beamercolorbox}[wd=\textwidth,ht=3ex,dp=3ex,leftskip=0.3cm,rightskip=0.3cm]{structure}%
   \hfill\usebeamerfont{page number in head/foot}%
-  \if@noTotalSlides
-  \insertpagenumber%
-  \else
+  \if@useTotalSlideIndicator%
   \insertpagenumber/\insertpresentationendpage%
-  \fi
+  \else%
+  \insertpagenumber%  
+  \fi%
 \end{beamercolorbox}%
 }
 
@@ -267,11 +273,21 @@
 \setbeamertemplate{frametitle}{%
 \nointerlineskip
 \begin{beamercolorbox}[wd=\paperwidth,leftskip=0.3cm,rightskip=0.3cm,ht=2.5ex,dp=1.5ex]{frametitle}
-\if@protectFrameTitle
-  \usebeamerfont{frametitle}\protect\insertframetitle%
-\else
-  \usebeamerfont{frametitle}\insertframetitle%
-\fi
+\usebeamerfont{frametitle}%
+\if@protectFrameTitle%
+  \protect%
+  \if@noSmallCapitals%
+    \insertframetitle%
+  \else%
+    \textsc{\MakeLowercase{\insertframetitle}}%
+  \fi%
+\else%
+  \if@noSmallCapitals%
+    \insertframetitle%
+  \else%
+    \textsc{\MakeLowercase{\insertframetitle}}%
+  \fi%
+\fi%
 \end{beamercolorbox}%
 \if@useTitleProgressBar
   \vspace{-.5em}


### PR DESCRIPTION
I have added **three options** to let the author decide how the beamer presentation should look like instead of forcing a specific behavior:

- **usesmallcapitalsintitle**: print frame titles in small capitals. I made this optional because small capitals are harder to read than alternating cases.
- **usesectionslide**: introduce a new section by an own slide. For short presentations with only a few slides, it is overkill to introduce each section with an own slide.
- **nototalslides**: print "#current/#total" slides per default. This indicates the progress and introduces almost no visual noise. Furthermore, I have used **\insertpagenumber** instead of **\insertframenumber** because each slide should have an unique "identifier" where questions can relate to. When using overlays, **\insertframenumber** uses the same frame number for each overlay.

See the diff for all code changes.