### PR TITLE
Tidy title slide code

### DIFF
--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -79,7 +79,7 @@
 		\setbox0=\vbox{\inserttitlegraphic}%
 		\logoheight=\ht0 \advance\logoheight by \dp0 %
 		\vspace*{-\logoheight}%
-		\vspace*{-1em}% I don't know why this additional negative space is needed
+		\nointerlineskip%
     }%
     \fi%
     \vfill

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -72,14 +72,13 @@
     \ifx\inserttitlegraphic\@empty%
     \else%
     {
-    	% actual output of titlegraphic
-   	    \usebeamercolor[fg]{titlegraphic}\inserttitlegraphic\par%
-    	% measurement and add negative vspace
-		\newdimen\logoheight
-		\setbox0=\vbox{\inserttitlegraphic}%
-		\logoheight=\ht0 \advance\logoheight by \dp0 %
-		\vspace*{-\logoheight}%
-		\nointerlineskip%
+      \vbox to 0pt
+      {% display title graphic without changing the position of other elements
+        \vspace*{2em}
+        \usebeamercolor[fg]{titlegraphic}%
+        \inserttitlegraphic{}%
+      }%
+      \nointerlineskip%
     }%
     \fi%
     \vfill

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -112,9 +112,10 @@
     \end{tikzpicture}%
     \vspace*{1em}%
 
-    \ifx\insertauthor\@empty\else
-    {{% \insertauthor is always nonempty by beamer's definition, so this
-      % code is always inserted:
+    \ifx\beamer@shortauthor\@empty\else
+    {{% \insertauthor is always nonempty by beamer's definition, so we must
+      % test another macro which is initialized by \author{...}
+      % For details, see http://tex.stackexchange.com/questions/241306/
       \usebeamerfont{author}%
       \usebeamercolor[fg]{author}%
       \insertauthor%

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -49,7 +49,6 @@
 
 %{{{ --- Packages ---------------------
 
-\RequirePackage{etoolbox}
 \RequirePackage{tikz}
 \RequirePackage{pgfplots}
 

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -108,7 +108,7 @@
     \else%
     {\usebeamerfont{date}\usebeamercolor[fg]{date}\insertdate\par}%
     \fi%
-    \ifx\insertinstitut\@empty%
+    \ifx\insertinstitute\@empty%
     \else%
     \vspace*{3mm}
     {\usebeamerfont{institute}\usebeamercolor[fg]{institute}\insertinstitute\par}%

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -63,55 +63,86 @@
 %{{{ --- Titlepage --------------------
 
 \def\maketitle{\ifbeamer@inframe\titlepage\else\frame[plain]{\titlepage}\fi}
-
 \def\titlepage{\usebeamertemplate{title page}}
+
 \setbeamertemplate{title page}
 {
   \begin{minipage}[b][\paperheight]{\textwidth}
     \vspace*{\@mtheme@voffset}
-    \ifx\inserttitlegraphic\@empty%
-    \else%
-    {
+
+    \ifx\inserttitlegraphic\@empty\else
+    {% \inserttitlegraphic is nonempty
       \vbox to 0pt
       {% display title graphic without changing the position of other elements
         \vspace*{2em}
         \usebeamercolor[fg]{titlegraphic}%
-        \inserttitlegraphic{}%
+        \inserttitlegraphic%
       }%
       \nointerlineskip%
-    }%
-    \fi%
-    \vfill
-    \ifx\inserttitle\@empty%
-    \else%
-    \if@noSmallCapitals%
-    {\raggedright\linespread{1.0}\usebeamerfont{title}\usebeamercolor[fg]{title}\inserttitle\par}%
-    \else%
-    {\raggedright\linespread{1.0}\usebeamerfont{title}\usebeamercolor[fg]{title}\scshape\MakeLowercase{\inserttitle}\par}%
-    \fi%
-    \vspace*{0.5em}
-    \fi%
-    \ifx\insertsubtitle\@empty%
-    \else%
-    {\usebeamerfont{subtitle}\usebeamercolor[fg]{subtitle}\insertsubtitle\par}%
-    \vspace*{0.5em}
-    \fi%
-    \begin{tikzpicture}\draw[alerted text.fg] (0, 0) -- (\textwidth, 0);\end{tikzpicture}%
-    \vspace*{1em}
-    \ifx\insertauthor\@empty%
-    \else%
-    {\usebeamerfont{author}\usebeamercolor[fg]{author}\insertauthor\par}%
-    \vspace*{0.25em}
-    \fi%
-    \ifx\insertdate\@empty%
-    \else%
-    {\usebeamerfont{date}\usebeamercolor[fg]{date}\insertdate\par}%
-    \fi%
-    \ifx\insertinstitute\@empty%
-    \else%
-    \vspace*{3mm}
-    {\usebeamerfont{institute}\usebeamercolor[fg]{institute}\insertinstitute\par}%
-    \fi%
+    }
+    \fi
+
+    \vfill%
+
+    \ifx\inserttitle\@empty\else
+    {{% \inserttitle is nonempty
+      \raggedright%
+      \linespread{1.0}%
+      \usebeamerfont{title}%
+      \usebeamercolor[fg]{title}%
+      \if@noSmallCapitals%
+        \inserttitle%
+      \else%
+        \scshape\MakeLowercase{\inserttitle}%
+      \fi%
+      \vspace*{0.5em}
+    }}
+    \fi
+
+    \ifx\insertsubtitle\@empty\else
+    {{% \insertsubtitle is nonempty
+      \usebeamerfont{subtitle}%
+      \usebeamercolor[fg]{subtitle}%
+      \insertsubtitle%
+      \vspace*{0.5em}%
+    }}
+    \fi
+
+    \begin{tikzpicture}
+      \draw[alerted text.fg] (0, 0) -- (\textwidth, 0);
+    \end{tikzpicture}%
+    \vspace*{1em}%
+
+    \ifx\insertauthor\@empty\else
+    {{% \insertauthor is always nonempty by beamer's definition, so this
+      % code is always inserted:
+      \usebeamerfont{author}%
+      \usebeamercolor[fg]{author}%
+      \insertauthor%
+      \par%
+      \vspace*{0.25em}
+    }}
+    \fi
+
+    \ifx\insertdate\@empty\else
+    {{% \insertdate is nonempty
+      \usebeamerfont{date}%
+      \usebeamercolor[fg]{date}%
+      \insertdate%
+      \par%
+    }}
+    \fi
+
+    \ifx\insertinstitute\@empty\else
+    {{% \insertinstitute is nonempty
+      \vspace*{3mm}
+      \usebeamerfont{institute}%
+      \usebeamercolor[fg]{institute}%
+      \insertinstitute%
+      \par%
+    }}
+    \fi
+
     \vfill
     \vspace*{\@mtheme@voffset}
   \end{minipage}


### PR DESCRIPTION
This pull request consists entirely of bugfixes and code formatting improvements, and should not affect presentation output except in corner cases.

- Fixes a bug causing unwanted space on the title slide when given an empty `\institute`. (Typo.)
- Fixes a bug causing unwanted space on the title slide when given an empty `\author`. (Apparently `\insertauthor` [works differently than the other title page elements](http://tex.stackexchange.com/questions/241306/).)
- Fixes the root cause of extra space following the title graphic, which previously had to be worked around with a negative vspace.
- Provides a more elegant solution for positioning title graphics.
- Makes the code more git-friendly by putting each formatting command on its own line.