### PR TITLE
Revert "Remove unused etoolbox package"

### DIFF
--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -49,6 +49,7 @@
 
 %{{{ --- Packages ---------------------
 
+\RequirePackage{etoolbox}
 \RequirePackage{tikz}
 \RequirePackage{pgfplots}
 


### PR DESCRIPTION
This reverts commit 736754ad5e972577dd88111d6d2359fd988702f9.

etoolbox is needed for \AtBeginEnvironment