### PR TITLE
use insertframenumber instead of insertpagenumber

### DIFF
--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -282,9 +282,9 @@
 \begin{beamercolorbox}[wd=\textwidth,ht=3ex,dp=3ex,leftskip=0.3cm,rightskip=0.3cm]{structure}%
   \hfill\usebeamerfont{page number in head/foot}%
   \if@useTotalSlideIndicator%
-  \insertpagenumber/\insertpresentationendpage%
+  \insertframenumber/\inserttotalframenumber%
   \else%
-  \insertpagenumber%
+  \insertframenumber%
   \fi%
 \end{beamercolorbox}%
 }


### PR DESCRIPTION
If we are using \only<> or other macro like this, it will show the
wrong number of slides in the footer. insertframenumber use the actual
frame number and it is not incremented when using \only<>