### PR TITLE
Only load font theme when compiling with XeLaTeX

### DIFF
--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -52,12 +52,18 @@
 \RequirePackage{etoolbox}
 \RequirePackage{tikz}
 \RequirePackage{pgfplots}
+\RequirePackage{ifxetex}
 
 \usetikzlibrary{backgrounds}
 \usetikzlibrary{calc}
 
 \usecolortheme{metropolis}
-\usefonttheme{metropolis}
+
+\ifxetex
+  \usefonttheme{metropolis}
+\else
+  \PackageWarning{beamerthemem}{You need to compile with XeLaTeX for the Fira fonts.}
+\fi
 
 %}}}
 %{{{ --- Titlepage --------------------


### PR DESCRIPTION
Currently, compiling the demo slides with `pdflatex` fails with `! Fatal fontspec error: "cannot-use-pdftex"
`. This is to be expected, since the `mtheme` requires XeLaTeX for the Fira fonts. However:

- in IDEs that display only the first line of each error message, users only get to see the cryptic error
    `fontspec.sty: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!` 
- there are situations where one may want to temporarily compile slides without XeLaTeX or the Fira fonts (for example, I often make tweaks to my talks on my Fira-less work computer before compiling them properly at home)

This PR addresses both issues by conditionally including the metropolis font theme only when `xelatex` is used. Under `pdflatex`, talks will successfully compile (albeit with ugly fonts) and throw a more informative one-line warning.
