### PR TITLE
Remove MakeLowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,26 @@ With option `nosectionslide`, no dedicated slide is produced when a new section
 starts. By default when using the `\section` command, a slide is created with
 just the title on it.
 
-The `nosmallcapitals` option supresses the usage of small capitals on
-title page, frame titles and dedicated section slides.
-
 Option `usetotalslideindicator` creates slide numbering in lower right corner
 in following format: #current/#total. By default, just current page number is
 printed.
 
+#### Title formatting
+
+The main title, section titles, and frame titles are all formatted according
+to the custom command `\mthemetitleformat`. By default, this is equivalent to
+`scshape` and sets the titles in small capitals, but you can change it in your
+preamble. For example:
+
+```latex
+\renewcommand{\mthemetitleformat}{}                       % no small capitals
+\renewcommand{\mthemetitleformat}{\scshape\MakeLowercase} % all small capitals
+\renewcommand{\mthemetitleformat}{\MakeUppercase}         % all capitals
+```
+
+Note that `\MakeLowercase` and `\MakeUppercase` can have unexpected behaviour
+in math mode, are disabled when `protectframetitle` is used, and cause crashes
+when an unprotected frametitle appears on a slide with `allowframebreaks`.
 
 #### Commands
 

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -13,13 +13,11 @@
 
 \newif\if@useTitleProgressBar
 \newif\if@protectFrameTitle
-\newif\if@noSmallCapitals
 \newif\if@noSectionSlide
 \newif\if@useTotalSlideIndicator
 
 \@useTitleProgressBarfalse
 \@protectFrameTitlefalse
-\@noSmallCapitalsfalse
 \@noSectionSlidefalse
 \@useTotalSlideIndicatorfalse
 
@@ -37,7 +35,6 @@
   \PackageWarning{beamerthemem}{Unknown option `\CurrentOption'}%
 }
 
-\DeclareOptionBeamer{nosmallcapitals}{\@noSmallCapitalstrue}
 \DeclareOptionBeamer{nosectionslide}{\@noSectionSlidetrue}
 \DeclareOptionBeamer{usetotalslideindicator}{\@useTotalSlideIndicatortrue}
 
@@ -96,11 +93,7 @@
       \linespread{1.0}%
       \usebeamerfont{title}%
       \usebeamercolor[fg]{title}%
-      \if@noSmallCapitals%
-        \inserttitle%
-      \else%
-        \scshape\mthemetitleformat{\inserttitle}%
-      \fi%
+      \mthemetitleformat{\inserttitle}%
       \vspace*{0.5em}
     }}
     \fi
@@ -178,20 +171,16 @@
 \newcommand{\insertsectionHEAD}{%
   \expandafter\insertsectionHEADaux\insertsectionhead}
 
-\if@noSmallCapitals%
-\newcommand{\insertsectionHEADaux}[3]{#3}%
-\else%
-\newcommand{\insertsectionHEADaux}[3]{\scshape \mthemetitleformat{#3}}%
-\fi%
+\newcommand{\insertsectionHEADaux}[3]{\mthemetitleformat{#3}}%
 
-\def\mthemetitleformat#1{#1}
+\def\mthemetitleformat#1{\scshape #1}
 
 \newcommand{\plain}[2][]{%
   \begingroup
   \setbeamercolor{background canvas}{use=palette primary,bg=palette primary.fg}
   \begin{frame}{#1}
     \centering
-    \vfill\vspace{1em}\usebeamerfont{section title}\textcolor{white}{\scshape \mthemetitleformat{#2}}\vfill
+    \vfill\vspace{1em}\usebeamerfont{section title}\textcolor{white}{\mthemetitleformat{#2}}\vfill
   \end{frame}
   \endgroup
 }
@@ -281,18 +270,9 @@
 \begin{beamercolorbox}[wd=\paperwidth,leftskip=0.3cm,rightskip=0.3cm,ht=2.5ex,dp=1.5ex]{frametitle}
 \usebeamerfont{frametitle}%
 \if@protectFrameTitle%
-  \protect%
-  \if@noSmallCapitals%
-    \insertframetitle%
-  \else%
-    \scshape\mthemetitleformat{\insertframetitle}%
-  \fi%
+    \mthemetitleformat{\protect\insertframetitle}%
 \else%
-  \if@noSmallCapitals%
-    \insertframetitle%
-  \else%
-    \scshape\mthemetitleformat{\insertframetitle}%
-  \fi%
+    \mthemetitleformat{\insertframetitle}%
 \fi%
 \end{beamercolorbox}%
 \if@useTitleProgressBar

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -99,7 +99,7 @@
       \if@noSmallCapitals%
         \inserttitle%
       \else%
-        \scshape\MakeLowercase{\inserttitle}%
+        \scshape\inserttitle%
       \fi%
       \vspace*{0.5em}
     }}
@@ -181,7 +181,7 @@
 \if@noSmallCapitals%
 \newcommand{\insertsectionHEADaux}[3]{#3}%
 \else%
-\newcommand{\insertsectionHEADaux}[3]{\textsc{\MakeLowercase{#3}}}%
+\newcommand{\insertsectionHEADaux}[3]{\scshape #3}%
 \fi%
 
 \newcommand{\plain}[2][]{%
@@ -283,13 +283,13 @@
   \if@noSmallCapitals%
     \insertframetitle%
   \else%
-    \textsc{\MakeLowercase{\insertframetitle}}%
+    \scshape\insertframetitle%
   \fi%
 \else%
   \if@noSmallCapitals%
     \insertframetitle%
   \else%
-    \textsc{\MakeLowercase{\insertframetitle}}%
+    \scshape\insertframetitle%
   \fi%
 \fi%
 \end{beamercolorbox}%

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -99,7 +99,7 @@
       \if@noSmallCapitals%
         \inserttitle%
       \else%
-        \scshape\inserttitle%
+        \scshape\mthemetitleformat{\inserttitle}%
       \fi%
       \vspace*{0.5em}
     }}
@@ -181,15 +181,17 @@
 \if@noSmallCapitals%
 \newcommand{\insertsectionHEADaux}[3]{#3}%
 \else%
-\newcommand{\insertsectionHEADaux}[3]{\scshape #3}%
+\newcommand{\insertsectionHEADaux}[3]{\scshape \mthemetitleformat{#3}}%
 \fi%
+
+\def\mthemetitleformat#1{#1}
 
 \newcommand{\plain}[2][]{%
   \begingroup
   \setbeamercolor{background canvas}{use=palette primary,bg=palette primary.fg}
   \begin{frame}{#1}
     \centering
-    \vfill\vspace{1em}\usebeamerfont{section title}\textcolor{white}{\scshape #2}\vfill
+    \vfill\vspace{1em}\usebeamerfont{section title}\textcolor{white}{\scshape \mthemetitleformat{#2}}\vfill
   \end{frame}
   \endgroup
 }
@@ -283,13 +285,13 @@
   \if@noSmallCapitals%
     \insertframetitle%
   \else%
-    \scshape\insertframetitle%
+    \scshape\mthemetitleformat{\insertframetitle}%
   \fi%
 \else%
   \if@noSmallCapitals%
     \insertframetitle%
   \else%
-    \scshape\insertframetitle%
+    \scshape\mthemetitleformat{\insertframetitle}%
   \fi%
 \fi%
 \end{beamercolorbox}%


### PR DESCRIPTION
Although it makes the small-caps frame titles look nice, the `mtheme`'s use of `\MakeLowercase` causes several other problems:

- The crash described in #20 is (somehow) caused when `\MakeLowercase` is called in the automatically generated extra frame titles.
- As #33 points out, `\MakeLowercase` only changes the case of letters in the English alphabet, producing undesirable results in common cases where the frame title contains numerals or non-Latin Unicode characters.
- Finally, `\MakeLowercase` sets a potentially bad trap for users. You might want to give a talk about "ᴀɴ *O(n²)* ᴀʟɢᴏʀɪᴛʜᴍ", for example, and write the obvious `\frametitle{An $O(n^2)$ algorithm}`. This appears to work as desired: the title font and small-caps shape do not apply to the math-mode part. But on closer inspection, `\MakeLowercase` *does* apply in math mode, so the title's meaning is unexpectedly distorted to "ᴀɴ *o(n²)* ᴀʟɢᴏʀɪᴛʜᴍ".

These downsides are significant enough to consider giving up the automatic lower-casing of titles: it's easy enough for an author to manually write their titles in lower case, but a major headache to work around these problems. This PR removes all instances of `\MakeLowercase` from the `mtheme`.