### PR TITLE
Addresses issue with TeX capacity exceeded

### DIFF
--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -278,10 +278,19 @@
 \nointerlineskip
 \begin{beamercolorbox}[wd=\paperwidth,leftskip=0.3cm,rightskip=0.3cm,ht=2.5ex,dp=1.5ex]{frametitle}
 \usebeamerfont{frametitle}%
-\if@noSmallCapitals%
-  \protect\insertframetitle%
-\else%
-  \textsc{\MakeLowercase{\protect\insertframetitle}}%
+\if@protectFrameTitle%
+  \protect%
+  \if@noSmallCapitals%
+    \insertframetitle%
+  \else%
+   \textsc{\MakeLowercase{\insertframetitle}}%
+  \fi%
+ \else%
+  \if@noSmallCapitals%
+    \insertframetitle%
+  \else%
+    \textsc{\MakeLowercase{\insertframetitle}}%
+  \fi%
 \fi%
 \end{beamercolorbox}%
 \if@useTitleProgressBar

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -278,19 +278,10 @@
 \nointerlineskip
 \begin{beamercolorbox}[wd=\paperwidth,leftskip=0.3cm,rightskip=0.3cm,ht=2.5ex,dp=1.5ex]{frametitle}
 \usebeamerfont{frametitle}%
-\if@protectFrameTitle%
-  \protect%
-  \if@noSmallCapitals%
-    \insertframetitle%
-  \else%
-    \textsc{\MakeLowercase{\insertframetitle}}%
-  \fi%
+\if@noSmallCapitals%
+  \protect\insertframetitle%
 \else%
-  \if@noSmallCapitals%
-    \insertframetitle%
-  \else%
-    \textsc{\MakeLowercase{\insertframetitle}}%
-  \fi%
+  \textsc{\MakeLowercase{\protect\insertframetitle}}%
 \fi%
 \end{beamercolorbox}%
 \if@useTitleProgressBar

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 set -xe
 xelatex -shell-escape demo.tex
+bibtex demo.aux
 xelatex -shell-escape demo.tex

--- a/demo.bib
+++ b/demo.bib
@@ -1,0 +1,41 @@
+@article{Knuth92,
+        author = "D.E. Knuth",
+        title = "Two notes on notation",
+        journal = "Amer. Math. Monthly",
+        volume = "99",
+        year = "1992",
+        pages = "403--422",
+}
+
+@book{ConcreteMath,
+        author = "R.L. Graham and D.E. Knuth and O. Patashnik",
+        title = "Concrete mathematics",
+        publisher = "Addison-Wesley",
+        address = "Reading, MA",
+        year = "1989"
+}
+
+@unpublished{Simpson,
+        author = "H. Simpson",
+        title = "Proof of the {R}iemann {H}ypothesis",
+        note = "preprint (2003), available at 
+        \texttt{http://www.math.drofnats.edu/riemann.ps}",
+}
+
+@incollection{Er01,
+        author = "P. Erd{\H o}s",
+        title = "A selection of problems and results in combinatorics",
+        booktitle = "Recent trends in combinatorics (Matrahaza, 1995)",
+        publisher = "Cambridge Univ. Press",
+        address = "Cambridge",
+        pages = "1--6"
+}
+@article{greenwade93,
+    author  = "George D. Greenwade",
+    title   = "The {C}omprehensive {T}ex {A}rchive {N}etwork ({CTAN})",
+    year    = "1993",
+    journal = "TUGBoat",
+    volume  = "14",
+    number  = "3",
+    pages   = "342--351"
+}

--- a/demo.tex
+++ b/demo.tex
@@ -180,6 +180,11 @@ or show \textbf{bold} results.\end{verbatim}
   \end{quote}
 \end{frame}
 
+\begin{frame}{References}
+
+  Some prominent TeXing \cite{knuth92,ConcreteMath,Simpson,Er01,greenwade93}
+
+\end{frame}
 
 \section{Conclusion}
 
@@ -198,5 +203,14 @@ or show \textbf{bold} results.\end{verbatim}
 \end{frame}
 
 \plain{Questions?}
+
+\begin{frame}[allowframebreaks]
+
+  \frametitle{References}
+
+  \bibliography{demo}
+  \bibliographystyle{plainnat}
+
+\end{frame}
 
 \end{document}


### PR DESCRIPTION
\begin{frame}[allowframebreaks] needs the title to be protected when
autobreaking because that is fragile.

There may be some [side-effects](http://texblog.net/help/latex/fragile.html)
when applying \protect to the title if used in combination with length and
counter commands.

Fixes #20 