### PR TITLE
Added 'noslidenumbers' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ printed.
 
 Option `noslidenumbers` omits slide numbers entirely.
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 #### Title formatting
 
 The main title, section titles, and frame titles are all formatted according
@@ -87,12 +85,6 @@ preamble. For example:
 Note that `\MakeLowercase` and `\MakeUppercase` can have unexpected behaviour
 in math mode, are disabled when `protectframetitle` is used, and cause crashes
 when an unprotected frametitle appears on a slide with `allowframebreaks`.
-=======
-Option `noslidenumbers` omits slide numbers entirely.
-
->>>>>>> Added 'noslidenumbers' to "Package Options"
-=======
->>>>>>> e84954b11b0fab8c9109d2e5101dc903f0cea7da
 
 #### Commands
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ can run the following command
 
 #### Package options
 
+To use any of options below, call them when invoking *mtheme* in the header of your document: `\usetheme[<options>]{m}`
+
 The `usetitleprogressbar` option adds a thin progress bar similar to the section
 progress bar underneath *each* frame title
 
@@ -65,6 +67,7 @@ Option `usetotalslideindicator` creates slide numbering in lower right corner
 in following format: #current/#total. By default, just current page number is
 printed.
 
+<<<<<<< HEAD
 #### Title formatting
 
 The main title, section titles, and frame titles are all formatted according
@@ -81,6 +84,10 @@ preamble. For example:
 Note that `\MakeLowercase` and `\MakeUppercase` can have unexpected behaviour
 in math mode, are disabled when `protectframetitle` is used, and cause crashes
 when an unprotected frametitle appears on a slide with `allowframebreaks`.
+=======
+Option `noslidenumbers` omits slide numbers entirely.
+
+>>>>>>> Added 'noslidenumbers' to "Package Options"
 
 #### Commands
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Option `usetotalslideindicator` creates slide numbering in lower right corner
 in following format: #current/#total. By default, just current page number is
 printed.
 
+Option `noslidenumbers` omits slide numbers entirely.
+
 <<<<<<< HEAD
 #### Title formatting
 

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -15,11 +15,13 @@
 \newif\if@protectFrameTitle
 \newif\if@noSectionSlide
 \newif\if@useTotalSlideIndicator
+\newif\if@noSlideNumbers
 
 \@useTitleProgressBarfalse
 \@protectFrameTitlefalse
 \@noSectionSlidefalse
 \@useTotalSlideIndicatorfalse
+\@noSlideNumbersfalse
 
 \newlength{\@mtheme@voffset}
 \setlength{\@mtheme@voffset}{2em}
@@ -37,6 +39,7 @@
 
 \DeclareOptionBeamer{nosectionslide}{\@noSectionSlidetrue}
 \DeclareOptionBeamer{usetotalslideindicator}{\@useTotalSlideIndicatortrue}
+\DeclareOptionBeamer{noslidenumbers}{\@noSlideNumberstrue}
 
 \ProcessOptionsBeamer
 
@@ -247,10 +250,14 @@
 {%
 \begin{beamercolorbox}[wd=\textwidth,ht=3ex,dp=3ex,leftskip=0.3cm,rightskip=0.3cm]{structure}%
   \hfill\usebeamerfont{page number in head/foot}%
-  \if@useTotalSlideIndicator%
-  \insertframenumber/\inserttotalframenumber%
+\if@noSlideNumbers%
+  %Purposefully left blank to display no slide number.%
   \else%
-  \insertframenumber%
+    \if@useTotalSlideIndicator%
+    \insertframenumber/\inserttotalframenumber%
+    \else%
+    \insertframenumber%
+    \fi%
   \fi%
 \end{beamercolorbox}%
 }


### PR DESCRIPTION
I needed the ability to suppress slide numbering throughout my presentations, so I added a `noslidenumbers` option that can be invoked with the theme to omit page numbers in the footer.

I should mention that this is my first time working with a .sty file, so I might not have done this in the most elegant way possible. I had difficulty finding any documentation on how the `\if` command was working, so I couldn't figure out a way to add a third conditional. As such, I nested two `\if` commands to produce the desired result. If there's a better way to do this, that would be great to see, but I think being able to suppress page numbers is an important option for such a minimalist theme.

Thanks for the awesome theme! Looks great and excited to use it!