### PR TITLE
Fix footer readability

### DIFF
--- a/beamercolorthememetropolis.sty
+++ b/beamercolorthememetropolis.sty
@@ -53,7 +53,7 @@
 \setbeamercolor{normal text}{fg=black!97}
 \setbeamercolor{alerted text}{fg=mLightBrown}
 
-\setbeamercolor{footnote}{fg=mDarkTeal!50}
+\setbeamercolor{footnote}{fg=mDarkTeal!90}
 \setbeamercolor{footnote mark}{fg=.}
 \setbeamercolor{page number in head/foot}{fg=mDarkTeal}
 


### PR DESCRIPTION
Light grey type on a white background poses issues regarding usability and readability, especially for older people or when using a bad quality projector.
Thus, I suggest using at least a darker variant of grey to increase contrast.