### PR TITLE
Simplify colour theme for easy customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ presentations, you can run the following command
 
 #### Package options
 
-To use any of options below, call them when invoking *mtheme* in the preabmle of
+To use any of options below, call them when invoking *mtheme* in the preamble of
 the slides, i.e.
 
 ```latex
-  \usetheme[<options>]{m}
+\usetheme[<options>]{m}
 ```
 
 * The `usetitleprogressbar` option adds a thin progress bar similar to the
@@ -66,6 +66,25 @@ the slides, i.e.
   in following format: #current/#total. By default, just current page number is
   printed.
 * Option `noslidenumbers` omits slide numbers entirely.
+
+#### Color customization
+
+The included `metropolis` color theme is used by default, but its colours can
+be easily changed to suit your tastes. All of the theme's styles are defined
+in terms of three beamer colors:
+
+- `normal text`     (dark fg, light bg)
+- `alerted text`    (colored fg, should be visible against dark or light)
+- `example text`    (colored fg, should be visible against dark or light)
+
+An easy way to customize the theme is to redefine these colors using
+
+```latex
+\setbeamercolor{ ... }{ fg= ... , bg= ... }
+```
+
+in your preamble. For greater customization, you can redefine any of the other
+colors in `beamercolorthememetropolis`, including `progress bar`.
 
 
 #### Title formatting

--- a/beamercolorthememetropolis.sty
+++ b/beamercolorthememetropolis.sty
@@ -106,8 +106,11 @@
 %
 
 \setbeamercolor{frametitle}{use=palette primary, parent=palette primary}
-\setbeamercolor{progress bar}{use=alerted text, parent=alerted text}
-\setbeamercolor{progress bar incomplete}{use=structure, parent=structure}
+\setbeamercolor{progress bar}{%
+  use={alerted text, structure},
+  fg=alerted text.fg,
+  bg=structure.fg
+}
 
 \setbeamercolor{background canvas}{use=normal text, parent=normal text}
 \setbeamercolor{titlelike}{use=normal text, parent=normal text}

--- a/beamercolorthememetropolis.sty
+++ b/beamercolorthememetropolis.sty
@@ -3,19 +3,23 @@
 % Copyright 2014 Matthias Vogelgesang
 % Licensed under CC-BY-SA 4.0 International.
 %
-% The initial template comes from the HSRM beamer theme by Benjamin Weiss, which
-% you can find at https://github.com/hsrmbeamertheme/hsrmbeamertheme.
-%
 
 \ProvidesPackage{beamercolorthememetropolis}
 
 
-%}}}
-%{{{ --- Options ----------------------
+% Options
+% =======
+
+% Option: blockbg
+%         applies a gray background to blocks
 
 \newif\if@beamer@metropolis@blockbg
 \@beamer@metropolis@blockbgfalse
-\DeclareOptionBeamer{blockbg}{\@beamer@metropolis@blockbgtrue}
+\DeclareOptionBeamer{blockbg}{
+    \@beamer@metropolis@blockbgtrue
+}
+
+% Option: ...
 
 \DeclareOptionBeamer*{%
   \PackageWarning{beamercolorthememetropolis}{Unknown option `\CurrentOption'}%
@@ -23,50 +27,92 @@
 
 \ProcessOptionsBeamer
 
-%}}}
-%{{{ --- Colors ---------------------
 
-% http://paletton.com/#uid=7050t0kkJkJsntwoyp6gYgoddc4
+
+% Color definitions
+% =================
+%
+% See http://paletton.com/#uid=7050t0kkJkJsntwoyp6gYgoddc4
+%
 
 \definecolor{mDarkBrown}{HTML}{604c38}
 \definecolor{mDarkTeal}{HTML}{23373b}
-
 \definecolor{mLightBrown}{HTML}{EB811B}
-\definecolor{mMediumBrown}{HTML}{C87A2F}
 
-\setbeamercolor{palette primary}{fg=mDarkTeal, bg=black!2}
-\setbeamercolor{palette secondary}{fg=white, bg=mDarkTeal}
-\setbeamercolor{palette tertiary}{fg=white, bg=mMediumBrown}
-\setbeamercolor{palette quaternary}{fg=mDarkBrown}
 
-\setbeamercolor{title}{parent=palette primary}
-\setbeamercolor{subtitle}{parent=palette primary}
-\setbeamercolor{author}{parent=palette primary}
-\setbeamercolor{date}{parent=palette primary}
-\setbeamercolor{institute}{parent=palette primary}
 
-\setbeamercolor{section title}{parent=palette primary}
-\setbeamercolor{frametitle}{parent=palette secondary}
-\setbeamercolor{background canvas}{parent=palette primary}
-\setbeamercolor{structure}{fg=mDarkTeal}
+% Base colors
+% ===========
+%
+% The metropolis color theme is defined in terms of four main styles:
+%
+% - normal text  (dark fg, light bg)
+% - alerted text (colored fg, should be visible against dark or light)
+% - structure    (light fg, dark bg)
+% - block title  (dark fg, light-ish bg)
+%
+% An easy way to customize the theme is to redefine these colors using
+%
+%     \setbeamercolor{ ... }{ fg= ... , bg= ... }
+%
+% in your preamble.
+%
 
-\setbeamercolor{normal text}{fg=black!97}
-\setbeamercolor{alerted text}{fg=mLightBrown}
+\setbeamercolor{normal text}{%
+  fg=mDarkTeal,
+  bg=black!2
+}
 
-\setbeamercolor{footnote}{fg=mDarkTeal!90}
-\setbeamercolor{footnote mark}{fg=.}
-\setbeamercolor{page number in head/foot}{fg=mDarkTeal}
+\setbeamercolor{alerted text}{%
+  fg=mLightBrown
+}
+
+\setbeamercolor{structure}{%
+  fg=white,
+  bg=mDarkTeal
+}
 
 \if@beamer@metropolis@blockbg
-
-\setbeamercolor{block title}{use=palette primary,parent=palette primary,bg=palette primary.bg!80!fg}
-\setbeamercolor{block title alerted}{use={palette primary,alerted text},parent=palette primary,fg=alerted text.fg,bg=palette primary.bg!80!fg}
-\setbeamercolor{block title example}{use={palette primary,example text},parent=palette primary,fg=example text.fg,bg=palette primary.bg!80!fg}
-
-\setbeamercolor{block body}{use=block title,parent=normal text,bg=block title.bg!50}
-\setbeamercolor{block body alerted}{use={normal text,block body},parent=normal text,bg=block body.bg}
-\setbeamercolor{block body example}{use={normal text,block body},parent=normal text,bg=block body.bg}
-
+  \setbeamercolor{block title}{%
+    use=normal text,
+    fg=normal text.fg,
+    bg=normal text.bg!80!fg
+  }
+\else
+  \setbeamercolor{block title}{use=normal text, parent=normal text}
 \fi
+
+
+
+% Derived colors
+% ==============
+%
+% These colors are all defined in terms of the four above. Beamer colors not
+% defined here are inherited from `beamercolorthemedefault.sty`
+%
+
+\setbeamercolor{frametitle}{use=structure, parent=structure}
+
+\setbeamercolor{background canvas}{use=normal text, parent=normal text}
+\setbeamercolor{titlelike}{use=normal text, parent=normal text}
+
+\setbeamercolor{footnote}{fg=normal text.fg!90}
+\setbeamercolor{footnote mark}{fg=.}
+
+\setbeamercolor{block body}{
+  use=block title,
+  bg=block title.bg!50
+}
+\setbeamercolor{block title alerted}{%
+    use={block title, alerted text},
+    bg=block title.bg,
+    fg=alerted text.fg
+}
+\setbeamercolor{block title example}{%
+    use={block title, example text},
+    bg=block title.bg,
+    fg=example text.fg
+}
+
 
 \mode<all>

--- a/beamercolorthememetropolis.sty
+++ b/beamercolorthememetropolis.sty
@@ -76,8 +76,10 @@
 \setbeamercolor{progress bar}{%
   use=alerted text,
   fg=alerted text.fg,
-  bg=mDarkTeal!50
+  bg=normal text.bg!50!fg
 }
+
+\setbeamercolor{title separator}{use=progress bar, parent=progress bar}
 
 \setbeamercolor{palette primary}{%
   % The “primary” palette should be used for the most important navigational

--- a/beamercolorthememetropolis.sty
+++ b/beamercolorthememetropolis.sty
@@ -38,7 +38,7 @@
 \definecolor{mDarkBrown}{HTML}{604c38}
 \definecolor{mDarkTeal}{HTML}{23373b}
 \definecolor{mLightBrown}{HTML}{EB811B}
-
+\definecolor{mLightGreen}{HTML}{14B03D}
 
 
 % Base colors
@@ -46,10 +46,12 @@
 %
 % The metropolis color theme is defined in terms of four main styles:
 %
-% - normal text  (dark fg, light bg)
-% - alerted text (colored fg, should be visible against dark or light)
-% - structure    (light fg, dark bg)
-% - block title  (dark fg, light-ish bg)
+% - normal text     (dark fg, light bg)
+% - alerted text    (colored fg, should be visible against dark or light)
+% - example text    (colored fg, should be visible against dark or light)
+% - structure       (dark-ish fg)
+% - palette primary (light fg, dark bg)
+% - block title     (dark fg, light-ish bg)
 %
 % An easy way to customize the theme is to redefine these colors using
 %
@@ -67,9 +69,21 @@
   fg=mLightBrown
 }
 
+\setbeamercolor{example text}{%
+  fg=mLightGreen
+}
+
 \setbeamercolor{structure}{%
-  fg=white,
-  bg=mDarkTeal
+  fg=mDarkTeal!50
+}
+
+\setbeamercolor{palette primary}{%
+  % The “primary” palette should be used for the most important navigational
+  % elements, and possibly of other elements.
+  % The metropolis color theme uses it for frame titles and `\plain` slides.
+  use=normal text,
+  fg=normal text.bg,
+  bg=normal text.fg
 }
 
 \if@beamer@metropolis@blockbg
@@ -91,7 +105,7 @@
 % defined here are inherited from `beamercolorthemedefault.sty`
 %
 
-\setbeamercolor{frametitle}{use=structure, parent=structure}
+\setbeamercolor{frametitle}{use=palette primary, parent=palette primary}
 
 \setbeamercolor{background canvas}{use=normal text, parent=normal text}
 \setbeamercolor{titlelike}{use=normal text, parent=normal text}
@@ -100,9 +114,11 @@
 \setbeamercolor{footnote mark}{fg=.}
 
 \setbeamercolor{block body}{
-  use=block title,
-  bg=block title.bg!50
+  use={block title, normal text},
+  bg=block title.bg!50!normal text.bg
 }
+\setbeamercolor{block body alerted}{use=block body, parent=block body}
+\setbeamercolor{block body example}{use=block body, parent=block body}
 \setbeamercolor{block title alerted}{%
     use={block title, alerted text},
     bg=block title.bg,

--- a/beamercolorthememetropolis.sty
+++ b/beamercolorthememetropolis.sty
@@ -44,12 +44,12 @@
 % Base colors
 % ===========
 %
-% The metropolis color theme is defined in terms of four main styles:
+% The metropolis color theme is defined in terms of several main styles:
 %
 % - normal text     (dark fg, light bg)
 % - alerted text    (colored fg, should be visible against dark or light)
 % - example text    (colored fg, should be visible against dark or light)
-% - structure       (dark-ish fg)
+% - progress bar    (colored fg, light-ish bg)
 % - palette primary (light fg, dark bg)
 % - block title     (dark fg, light-ish bg)
 %
@@ -73,8 +73,10 @@
   fg=mLightGreen
 }
 
-\setbeamercolor{structure}{%
-  fg=mDarkTeal!50
+\setbeamercolor{progress bar}{%
+  use=alerted text,
+  fg=alerted text.fg,
+  bg=mDarkTeal!50
 }
 
 \setbeamercolor{palette primary}{%
@@ -106,14 +108,14 @@
 %
 
 \setbeamercolor{frametitle}{use=palette primary, parent=palette primary}
-\setbeamercolor{progress bar}{%
-  use={alerted text, structure},
-  fg=alerted text.fg,
-  bg=structure.fg
-}
 
 \setbeamercolor{background canvas}{use=normal text, parent=normal text}
 \setbeamercolor{titlelike}{use=normal text, parent=normal text}
+\setbeamercolor{structure}{%
+  % This would be parent=normal text, but the inheritance is overriden by the
+  % explicity color definition for structure in `beamercolorthemedefault.sty`
+  fg=normal text.fg
+}
 
 \setbeamercolor{footnote}{fg=normal text.fg!90}
 \setbeamercolor{footnote mark}{fg=.}

--- a/beamercolorthememetropolis.sty
+++ b/beamercolorthememetropolis.sty
@@ -44,14 +44,11 @@
 % Base colors
 % ===========
 %
-% The metropolis color theme is defined in terms of several main styles:
+% The metropolis color theme is defined in terms of three fundamental styles:
 %
 % - normal text     (dark fg, light bg)
 % - alerted text    (colored fg, should be visible against dark or light)
 % - example text    (colored fg, should be visible against dark or light)
-% - progress bar    (colored fg, light-ish bg)
-% - palette primary (light fg, dark bg)
-% - block title     (dark fg, light-ish bg)
 %
 % An easy way to customize the theme is to redefine these colors using
 %
@@ -73,14 +70,32 @@
   fg=mLightGreen
 }
 
-\setbeamercolor{progress bar}{%
-  use=alerted text,
-  fg=alerted text.fg,
-  bg=normal text.bg!50!fg
+
+
+% Derived colors
+% ==============
+%
+% These colors are all defined in terms of the above and will update their
+% appearance if `normal text`, `alerted text`, or `example text` is customized.
+%
+% You may also redefine these in your preamble for greater control over the
+% customization. Beamer colors not defined here are inherited from
+% `beamercolorthemedefault.sty`
+%
+
+% Reset titles and structure to normal text
+
+\setbeamercolor{titlelike}{use=normal text, parent=normal text}
+\setbeamercolor{structure}{%
+  % This would be parent=normal text, but the inheritance is overriden by the
+  % explicity color definition for structure in `beamercolorthemedefault.sty`
+  fg=normal text.fg
 }
 
-\setbeamercolor{title separator}{use=progress bar, parent=progress bar}
 
+% Frame titles and `\plain` slides
+
+\setbeamercolor{frametitle}{use=palette primary, parent=palette primary}
 \setbeamercolor{palette primary}{%
   % The “primary” palette should be used for the most important navigational
   % elements, and possibly of other elements.
@@ -89,6 +104,19 @@
   fg=normal text.bg,
   bg=normal text.fg
 }
+
+
+% Progress bar and title separator
+
+\setbeamercolor{title separator}{use=progress bar, parent=progress bar}
+\setbeamercolor{progress bar}{%
+  use=alerted text,
+  fg=alerted text.fg,
+  bg=normal text.bg!50!fg
+}
+
+
+% Blocks
 
 \if@beamer@metropolis@blockbg
   \setbeamercolor{block title}{%
@@ -100,34 +128,6 @@
   \setbeamercolor{block title}{use=normal text, parent=normal text}
 \fi
 
-
-
-% Derived colors
-% ==============
-%
-% These colors are all defined in terms of the four above. Beamer colors not
-% defined here are inherited from `beamercolorthemedefault.sty`
-%
-
-\setbeamercolor{frametitle}{use=palette primary, parent=palette primary}
-
-\setbeamercolor{background canvas}{use=normal text, parent=normal text}
-\setbeamercolor{titlelike}{use=normal text, parent=normal text}
-\setbeamercolor{structure}{%
-  % This would be parent=normal text, but the inheritance is overriden by the
-  % explicity color definition for structure in `beamercolorthemedefault.sty`
-  fg=normal text.fg
-}
-
-\setbeamercolor{footnote}{fg=normal text.fg!90}
-\setbeamercolor{footnote mark}{fg=.}
-
-\setbeamercolor{block body}{
-  use={block title, normal text},
-  bg=block title.bg!50!normal text.bg
-}
-\setbeamercolor{block body alerted}{use=block body, parent=block body}
-\setbeamercolor{block body example}{use=block body, parent=block body}
 \setbeamercolor{block title alerted}{%
     use={block title, alerted text},
     bg=block title.bg,
@@ -138,6 +138,19 @@
     bg=block title.bg,
     fg=example text.fg
 }
+
+\setbeamercolor{block body alerted}{use=block body, parent=block body}
+\setbeamercolor{block body example}{use=block body, parent=block body}
+\setbeamercolor{block body}{
+  use={block title, normal text},
+  bg=block title.bg!50!normal text.bg
+}
+
+
+% Footnotes
+
+\setbeamercolor{footnote}{fg=normal text.fg!90}
+\setbeamercolor{footnote mark}{fg=.}
 
 
 \mode<all>

--- a/beamercolorthememetropolis.sty
+++ b/beamercolorthememetropolis.sty
@@ -106,6 +106,8 @@
 %
 
 \setbeamercolor{frametitle}{use=palette primary, parent=palette primary}
+\setbeamercolor{progress bar}{use=alerted text, parent=alerted text}
+\setbeamercolor{progress bar incomplete}{use=structure, parent=structure}
 
 \setbeamercolor{background canvas}{use=normal text, parent=normal text}
 \setbeamercolor{titlelike}{use=normal text, parent=normal text}

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -220,8 +220,10 @@
     #1 * \ratio{\insertframenumber pt}{\inserttotalframenumber pt}%
   }%
   \begin{tikzpicture}[tight background]
-    \draw[bg!50!fg, fill=bg!50!fg] (0,0) rectangle (#1, 0.4pt);
-    \draw[alerted text.fg, fill=alerted text.fg] (0,0) rectangle (\progressbar@percent, 0.4pt);
+    \usebeamercolor{progress bar incomplete}
+    \draw[fg, fill=fg] (0,0) rectangle (#1, 0.4pt);
+    \usebeamercolor{progress bar}
+    \draw[fg, fill=fg] (0,0) rectangle (\progressbar@percent, 0.4pt);
   \end{tikzpicture}%
 }
 

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -170,7 +170,8 @@
     \fi
 
     \begin{tikzpicture}
-      \draw[alerted text.fg] (0, 0) -- (\textwidth, 0);
+      \usebeamercolor{title separator}
+      \draw[fg] (0, 0) -- (\textwidth, 0);
     \end{tikzpicture}%
     \vspace*{1em}%
 

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -219,9 +219,8 @@
   \setlength{\progressbar@percent}{%
     #1 * \ratio{\insertframenumber pt}{\inserttotalframenumber pt}%
   }%
-  \usebeamercolor{palette primary}
   \begin{tikzpicture}[tight background]
-    \draw[fg!50, fill=fg!50] (0,0) rectangle (#1, 0.4pt);
+    \draw[bg!50!fg, fill=bg!50!fg] (0,0) rectangle (#1, 0.4pt);
     \draw[alerted text.fg, fill=alerted text.fg] (0,0) rectangle (\progressbar@percent, 0.4pt);
   \end{tikzpicture}%
 }
@@ -237,11 +236,16 @@
 
 \newcommand{\plain}[2][]{%
   \begingroup
-  \setbeamercolor{background canvas}{use=palette primary,bg=palette primary.fg}
-  \begin{frame}{#1}
-    \centering
-    \vfill\vspace{1em}\usebeamerfont{section title}\textcolor{white}{\mthemetitleformat{#2}}\vfill
-  \end{frame}
+    \setbeamercolor{background canvas}{use=structure,parent=structure}
+    \begin{frame}{#1}
+      \centering
+      \vfill
+      \vspace{1em}
+      \usebeamercolor[fg]{structure}
+      \usebeamerfont{section title}
+      \mthemetitleformat{#2}
+      \vfill
+    \end{frame}
   \endgroup
 }
 
@@ -285,10 +289,7 @@
     \ifbeamer@inframe
       \sectionpage
     \else
-      \begingroup
-      \setbeamercolor{background canvas}{parent=palette primary}
       \frame[plain]{\sectionpage}
-      \endgroup
     \fi
   }
 \fi
@@ -305,7 +306,7 @@
 \usenavigationsymbolstemplate{}
 \setbeamertemplate{footline}
 {%
-\begin{beamercolorbox}[wd=\textwidth,ht=3ex,dp=3ex,leftskip=0.3cm,rightskip=0.3cm]{structure}%
+\begin{beamercolorbox}[wd=\textwidth,ht=3ex,dp=3ex,leftskip=0.3cm,rightskip=0.3cm]{footline}%
   \hfill\usebeamerfont{page number in head/foot}%
 \if@noSlideNumbers%
   %Purposefully left blank to display no slide number.%

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -220,9 +220,8 @@
     #1 * \ratio{\insertframenumber pt}{\inserttotalframenumber pt}%
   }%
   \begin{tikzpicture}[tight background]
-    \usebeamercolor{progress bar incomplete}
-    \draw[fg, fill=fg] (0,0) rectangle (#1, 0.4pt);
     \usebeamercolor{progress bar}
+    \draw[bg, fill=bg] (0,0) rectangle (#1, 0.4pt);
     \draw[fg, fill=fg] (0,0) rectangle (\progressbar@percent, 0.4pt);
   \end{tikzpicture}%
 }

--- a/beamerthemem.sty
+++ b/beamerthemem.sty
@@ -236,12 +236,12 @@
 
 \newcommand{\plain}[2][]{%
   \begingroup
-    \setbeamercolor{background canvas}{use=structure,parent=structure}
+    \setbeamercolor{background canvas}{use=palette primary,parent=palette primary}
     \begin{frame}{#1}
       \centering
       \vfill
       \vspace{1em}
-      \usebeamercolor[fg]{structure}
+      \usebeamercolor[fg]{palette primary}
       \usebeamerfont{section title}
       \mthemetitleformat{#2}
       \vfill


### PR DESCRIPTION
This PR implements an alternative to #64 to simplify `beamercolorthememetropolis.sty` and make it more easily customizable. Users would be able to change the colour scheme by setting any subset of four basic beamer colours:

```latex
\setbeamercolor{normal text}{...}
\setbeamercolor{alerted text}{...}
\setbeamercolor{structure}{...}
\setbeamercolor{block title}{...}
```

This approach incorporates the semantic improvements suggested by #64 while keeping descriptive names for the primitive colours defined by `\definecolor`.