### PR TITLE
different font families and sizes in bibliography

### DIFF
--- a/beamerfontthememetropolis.sty
+++ b/beamerfontthememetropolis.sty
@@ -42,7 +42,7 @@
 \setbeamerfont{page number in head/foot}{size=\scriptsize}
 
 \setbeamerfont{bibliography entry author}{family=\Light, size=\normalsize}
-\setbeamerfont{bibliography entry title}{family=\Medium, size=\normalsize}
+\setbeamerfont{bibliography entry title}{family=\Book, size=\normalsize}
 \setbeamerfont{bibliography entry location}{family=\Light, size=\normalsize}
 \setbeamerfont{bibliography entry note}{family=\Light, size=\small}
 

--- a/beamerfontthememetropolis.sty
+++ b/beamerfontthememetropolis.sty
@@ -41,5 +41,9 @@
 
 \setbeamerfont{page number in head/foot}{size=\scriptsize}
 
+\setbeamerfont{bibliography entry author}{family=\Light, size=\normalsize}
+\setbeamerfont{bibliography entry title}{family=\Medium, size=\normalsize}
+\setbeamerfont{bibliography entry location}{family=\Light, size=\normalsize}
+\setbeamerfont{bibliography entry note}{family=\Light, size=\small}
 
 \linespread{1.15}


### PR DESCRIPTION
This PR implements the changes discussed in #66 regarding the bibliography.

Old:

![bib_screenshot_2](https://cloud.githubusercontent.com/assets/9158719/8090178/b86a0490-0fac-11e5-9b8b-abfeee5b7722.png)

New:

![bib_screenshot_1](https://cloud.githubusercontent.com/assets/9158719/8090176/b1cdc5ea-0fac-11e5-9910-7ca1eac3931f.png)

