### PR TITLE
removed document class option compress

### DIFF
--- a/demo.tex
+++ b/demo.tex
@@ -1,4 +1,4 @@
-\documentclass[10pt, compress]{beamer}
+\documentclass[10pt]{beamer}
 
 \usetheme{m}
 


### PR DESCRIPTION
This PR removes the unused `compress` option. No big thing. But it annoys me every time I see it. ;)