### PR TITLE
Added new font theme for thicker, easier to read letters.

### DIFF
--- a/beamerfontthemedailyplanet.sty
+++ b/beamerfontthemedailyplanet.sty
@@ -1,0 +1,55 @@
+% Beamer mtheme
+%
+% Copyright 2014 Matthias Vogelgesang
+% Licensed under CC-BY-SA 4.0 International.
+%
+% The initial template comes from the HSRM beamer theme by Benjamin Weiss, which
+% you can find at https://github.com/hsrmbeamertheme/hsrmbeamertheme.
+%
+% 'dailyplanet' font theme uses same font family of "Fira Sans/Mono" that Metropolis 
+% default does, but works with heavier weight fonts for easier readability (small
+% screens in mind). Majority of font is in "Fira Sans Book".
+
+\ProvidesPackage{beamerfontthemedailyplanet}
+
+\RequirePackage{fontspec}
+
+
+\defaultfontfeatures{Mapping=tex-text}
+\setsansfont[BoldItalicFont={Fira Sans SemiBold Italic}, ItalicFont={Fira Sans Book Italic}, BoldFont={Fira Sans SemiBold}]{Fira Sans Book}
+\setmonofont{Fira Mono}
+\newfontfamily\Light{Fira Sans Light}
+\newfontfamily\Book{Fira Sans Book}
+\newfontfamily\Regular{Fira Sans}
+\newfontfamily\SemiBold{Fira Sans SemiBold}
+
+
+
+\AtBeginEnvironment{tabular}{\setsansfont[BoldFont=Fira Sans SemiBold, Numbers={Monospaced}]{Fira Sans Book}}
+
+
+\setbeamerfont{title}{family=\Regular, size=\Large}
+\setbeamerfont{author}{family=\Book, size=\normalsize}
+\setbeamerfont{date}{family=\Light, size=\normalsize}
+
+\setbeamerfont{section title}{family=\Regular, size=\Large}
+
+\setbeamerfont{block title}{family=\Regular, size=\normalsize}
+\setbeamerfont{block title alerted}{family=\Regular,size=\normalsize}
+
+\setbeamerfont{subtitle}{family=\Light, size=\fontsize{12}{14}}
+\setbeamerfont{frametitle}{family=\Regular, size=\large}
+
+\setbeamerfont{caption}{size=\small}
+\setbeamerfont{caption name}{family=\SemiBold}
+
+\setbeamerfont{description item}{family=\Book}
+
+\setbeamerfont{page number in head/foot}{size=\scriptsize}
+
+\setbeamerfont{bibliography entry author}{family=\Book, size=\normalsize}
+\setbeamerfont{bibliography entry title}{family=\SemiBold, size=\normalsize}
+\setbeamerfont{bibliography entry location}{family=\Light, size=\normalsize}
+\setbeamerfont{bibliography entry note}{family=\Light, size=\small}
+
+\linespread{1.15}


### PR DESCRIPTION
Put together a new Beamer font theme: `dailyplanet`. Use with `\usefonttheme{dailyplanet}` sometime after `\usetheme[<options>]{m}` in the document header. This changes the normal font from Fira Sans `Light` to primarily using Fira Sans `Book`. Similar changes were made to the rest of the supporting font choices.

![fontprovingground](https://cloud.githubusercontent.com/assets/12464874/8143661/3210744e-116c-11e5-98e2-76cde4d007ea.png)

This font theme was made with high readability in mind. While I prefer the aesthetic quality of the default `metropolis` font theme, my use case necessitates readability on phone screens. The new theme also helps guarantee readability in other challenging situations, like large auditoriums and/or small projectors.

Some minor issues to deal with before this is ready to be merged:
- **Bibliography Fonts**: I really struggled with getting a bibliography to work in Beamer using xelatex and ultimately gave up. I tried to structure the bibliography entries around the same pattern that the default theme has, but someone else will have to verify that it isn't terrible.
- **Theme Name**: Is `dailyplanet` an acceptable name? It's a fun call back to the theme's name, but it isn't very descriptive. Then again, that issue might be mitigated in the future if we have documentation showing illustrations of each theme.
- **ReadMe**: Haven't touched the ReadMe yet. Wasn't sure if it was best to create another subsection (like the current *Color customization*), or list it somewhere else. If we create a subsection on *Font Customization*, should we also give some general pointers to the larger idea of using any font you want by making a custom font theme? Or just say how to use `dailyplanet` and leave it at that?


Finally (and I'm not sure if this is the proper GitHub etiquette or I should open an Issue for these things), the research I wound up doing prior to creating this new font theme led me to the discovery of these two packages. I thought they might be of interest if you didn't already know of them:
- [fira](http://www.ctan.org/pkg/fira) // **Fira Sans Fonts**: Provides Fira Sans and Fira Mono fonts, and works outside of xelatex/lualatex. I was playing around with it and typesetting just in plain pdflatex. Seems to be in pretty good shape, although it's important to make sure you're updated to the most recent version (2015-05-23) which fixes some major gaps.
- [newtxsf](http://ctan.org/pkg/newtxsf) // **Sans Math Fonts**: Provides sans-serif math fonts, such as Greek. Right now, I think there's a bit of an issue in `metropolis` with using Greek symbols, since they feel so different from Fira Sans. While this is less of an issue when using `Fira Sans Light`, it becomes especially noticeable if you're using the `dailyplanet` font theme (Take a look at \sin(\theta) in the image above). Using the `newtxsf` package gives a much more pleasing match to my eye.

Both of the above packages seem to be quite new (released after `mtheme` was posted), so I wanted to make sure I pointed them out.