### PR TITLE
Added custom block definitions, closes #76

### DIFF
--- a/beamerthemem.dtx
+++ b/beamerthemem.dtx
@@ -378,6 +378,91 @@
 \setlength{\parskip}{0.5em}
 %    \end{macrocode}
 %
+% Block environment
+%
+%    \begin{macrocode}
+
+\newlength{\leftrightskip}
+\if@beamer@metropolis@blockbg
+  \setlength{\leftrightskip}{1ex}
+\else
+  \setlength{\leftrightskip}{0ex}
+\fi
+\setbeamertemplate{block begin}{%
+  \vspace*{1ex}
+  \begin{beamercolorbox}[%
+    ht=2.4ex,
+    dp=1ex,
+    leftskip=\leftrightskip,
+    rightskip=\leftrightskip]{block title}
+      \usebeamerfont*{block title}\insertblocktitle%
+  \end{beamercolorbox}%
+  \vspace*{-1pt}
+  \usebeamerfont{block body}%
+  \begin{beamercolorbox}[%
+    dp=1ex,
+    leftskip=\leftrightskip,
+    rightskip=\leftrightskip,
+    vmode]{block body}%
+}
+\setbeamertemplate{block end}{%
+  \end{beamercolorbox}
+  \vspace*{0.2ex}
+}
+%    \end{macrocode}
+%
+% Alerted block environment
+%
+%    \begin{macrocode}
+\setbeamertemplate{block alerted begin}{%
+  \vspace*{1ex}
+  \begin{beamercolorbox}[%
+    ht=2.4ex,
+    dp=1ex,
+    leftskip=\leftrightskip,
+    rightskip=\leftrightskip]{block title alerted}
+      \usebeamerfont*{block title alerted}\insertblocktitle%
+  \end{beamercolorbox}%
+  \vspace*{-1pt}
+  \usebeamerfont{block body alerted}%
+  \begin{beamercolorbox}[%
+    dp=1ex,
+    leftskip=\leftrightskip,
+    rightskip=\leftrightskip,
+    vmode]{block body}%
+}
+\setbeamertemplate{block alerted end}{%
+  \end{beamercolorbox}
+  \vspace*{0.2ex}
+}
+%    \end{macrocode}
+%
+% Example block environment
+%
+%    \begin{macrocode}
+\setbeamertemplate{block example begin}{%
+  \vspace*{1ex}
+  \begin{beamercolorbox}[%
+    ht=2.4ex,
+    dp=1ex,
+    leftskip=\leftrightskip,
+    rightskip=\leftrightskip]{block title example}
+      \usebeamerfont*{block title example}\insertblocktitle%
+  \end{beamercolorbox}%
+  \vspace*{-1pt}
+  \usebeamerfont{block body example}%
+  \begin{beamercolorbox}[%
+    dp=1ex,
+    leftskip=\leftrightskip,
+    rightskip=\leftrightskip,
+    vmode]{block body}%
+}
+\setbeamertemplate{block example end}{%
+  \end{beamercolorbox}
+  \vspace*{0.2ex}
+}
+%    \end{macrocode}
+%
 % Sections
 %
 %    \begin{macrocode}


### PR DESCRIPTION
As announced I optimized the old definitions I used in the `hsrmbeamertheme` a little bit. The height of the title block is a little bit reduced and the text in it properly vertically centered. Also the code is refactorized and should be easier to read. Just take a look at it if everything looks fine now.

![screenshot_demo](https://cloud.githubusercontent.com/assets/9158719/8167136/8b9e227c-139c-11e5-909c-d3e6219a448d.png)

![screenshot_demo_blockbg](https://cloud.githubusercontent.com/assets/9158719/8167139/8f2742f2-139c-11e5-9f70-8161f8bce717.png)

If so, then I will, as soon as PR #77 is merged, recompile the `demo.pdf` and rebase.