### PR TITLE
typo in doc: \metroset needs CURLY braces

### DIFF
--- a/mtheme.dtx
+++ b/mtheme.dtx
@@ -207,12 +207,12 @@ either provide a comma separated list of options when invoking
 \end{lstlisting}
 Or you can set them at any time with the |\metroset| macro.
 \begin{lstlisting}
-\metroset[<key=value list>]
+\metroset{<key=value list>}
 \end{lstlisting}
 To set an option on a specific sub-package only you have to add the
 corresponding prefix (inner, outer, color), e.g.
 \begin{lstlisting}
-\metroset[inner/block=fill]
+\metroset{inner/block=fill}
 \end{lstlisting}
 The list of options is structured as shown in the following example.
 


### PR DESCRIPTION
I think this must have been a typo ... `\metroset[]` does *not* work.