### PR TITLE
Allow installation in any directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ DOC_PDF     = doc/metropolistheme.pdf
 
 CTAN_CONTENT = $(INS) $(PACKAGE_SRC) $(DOC_PDF)
 
-TEXMFHOME   = $(shell kpsewhich -var-value=TEXMFHOME)
-INSTALL_DIR = $(TEXMFHOME)/tex/latex/mtheme
-DOC_DIR     = $(TEXMFHOME)/doc/latex/mtheme
+DESTDIR     ?= $(shell kpsewhich -var-value=TEXMFHOME)
+INSTALL_DIR = $(DESTDIR)/tex/latex/mtheme
+DOC_DIR     = $(DESTDIR)/doc/latex/mtheme
 CACHE_DIR   := $(shell pwd)/.latex-cache
 
 COMPILE_TEX := latexmk -xelatex -output-directory=$(CACHE_DIR)


### PR DESCRIPTION
I would like to create packages to install mtheme on various Linux distros using the native package manager (apt-get, yum, paceman, etc). This makes it very easy to install the Fira fonts as dependencies. In order to achieve that, I need to be able to install the files in the staging area. Hence the patch to Makefile.