### PR TITLE
Fix font features for monospace fonts

### DIFF
--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -42,7 +42,7 @@
 %    \begin{macrocode}
 \ifboolexpr{bool {xetex} or bool {luatex}}{
   \RequirePackage[no-math]{fontspec}
-  \defaultfontfeatures{Mapping=tex-text}
+  \defaultfontfeatures[\rmfamily,\sffamily]{Ligatures=TeX}
 %    \end{macrocode}
 %
 % To simplify the check whether the |Fira| fonts are installed, a set macros is


### PR DESCRIPTION
Ligatures should not be turned on for monospaced fonts (you don't want curly quotes in code fragments and other special features). Also, `Ligatures=TeX` is the same as having `Mapping=tex-text`, but is more compatible with luatex (See sections 9.1 and 11.1 of the fontspec manual).