### PR TITLE
Remove unnecessary font features

### DIFF
--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -42,7 +42,6 @@
 %    \begin{macrocode}
 \ifboolexpr{bool {xetex} or bool {luatex}}{
   \RequirePackage[no-math]{fontspec}
-  \defaultfontfeatures{Mapping=tex-text}
 %    \end{macrocode}
 %
 % To simplify the check whether the |Fira| fonts are installed, a set macros is


### PR DESCRIPTION
The fontspec default font features are

```
\defaultfontfeatures
 [\rmfamily,\sffamily]
 {Ligatures=TeX}

\defaultfontfeatures
 [\ttfamily]
 {WordSpace={1,0,0},
  PunctuationSpace=WordSpace}
```

There isn't a reason to override this (see PR #154).