### PR TITLE
Added option to add a footer to the slides

### DIFF
--- a/demo/demo.tex
+++ b/demo/demo.tex
@@ -16,12 +16,9 @@
 \date{\today}
 \author{Matthias Vogelgesang}
 \institute{Center for modern beamer themes}
-% \titlegraphic{\hfill\includegraphics[height=1.5cm]{logo/logo}}
+\titlegraphic{\hfill\includegraphics[height=1.5cm]{logo.pdf}}
 
 \begin{document}
-
-% Set a custom footer text for all the slides
-\metroset{footer={custom=My footer}}
 
 \maketitle
 
@@ -282,6 +279,14 @@ or show \textbf{bold} results.\end{verbatim}
     Veni, Vidi, Vici
   \end{quote}
 \end{frame}
+
+{%
+\setbeamertemplate{frame footer}{My custom footer}
+\begin{frame}[fragile]{Frame footer}
+    \themename defines a custom beamer template to add a text to the footer. It can be set via
+    \begin{verbatim}\setbeamertemplate{frame footer}{My custom footer}\end{verbatim}
+\end{frame}
+}
 
 \begin{frame}{References}
   Some references to showcase [allowframebreaks] \cite{knuth92,ConcreteMath,Simpson,Er01,greenwade93}

--- a/demo/demo.tex
+++ b/demo/demo.tex
@@ -20,6 +20,9 @@
 
 \begin{document}
 
+% Set a custom footer text for all the slides
+\metroset{footer={custom=My footer}}
+
 \maketitle
 
 \begin{frame}{Table of contents}
@@ -65,7 +68,7 @@
 \end{frame}
 
 {
-\metroset{titleformat frame=smallcaps}
+    \metroset{titleformat frame=smallcaps}
 \begin{frame}{Small caps}
 	This frame uses the \texttt{smallcaps} titleformat.
 

--- a/doc/metropolistheme.dtx
+++ b/doc/metropolistheme.dtx
@@ -367,6 +367,10 @@ option on every sub-package accordingly.
 }
 
 \subsubsection{Outer theme}
+\DescribeOption{footer}{none, custom}{none}{
+    In the bottom left corner of each frame, a frame footer text (the section name by default) can be
+    displayed using (|custom|). This can be set to any text as footer={custom=My text}
+}
 \DescribeOption{numbering}{none, counter, fraction}{counter}{
   In the bottom right corner of each frame the current frame number is
   displayed. This can be disabled or the total framenumber can be added

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -44,13 +44,14 @@
 % \subsubsection{Options}
 %
 % \begin{macro}{footer}
-% This option controls the page left footer text.
-% The default custom footer is the section name.
-% We can change it with:
+% This option controls the page left footer text, using the
+% command
+% \setbeamertemplate{frame footer}{My custom footer}
+% but it can also be set with the command
 % \metroset{footer={custom=Some text}}
-% Maybe this is not the optimal solution, but it works for now
-% A possible nice way to do it is using this 
-% \href{http://tex.stackexchange.com/questions/149982/how-do-i-pass-an-unknown-value-to-a-choice-key-in-pgfkeys}{solution}
+% where, if no text is specified, i.e. doing
+% \metroset{footer={custom}}
+% it will show the section name.
 %    \begin{macrocode}
 \pgfkeys{
   /metropolis/outer/footer/.cd,
@@ -194,7 +195,6 @@
 \defbeamertemplate{footline}{plain}{%
   \begin{beamercolorbox}[wd=\textwidth, sep=3ex]{footline}%
     \usebeamerfont{page number in head/foot}%
-    \makebox[0pt][l]{}
     \usebeamertemplate*{frame footer}
     \hfill%
     \usebeamertemplate*{frame numbering}

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -43,6 +43,25 @@
 %
 % \subsubsection{Options}
 %
+% \begin{macro}{footer}
+% This option controls the page left footer text.
+% The default custom footer is the section name.
+% We can change it with:
+% \metroset{footer={custom=Some text}}
+% Maybe this is not the optimal solution, but it works for now
+% A possible nice way to do it is using this 
+% \href{http://tex.stackexchange.com/questions/149982/how-do-i-pass-an-unknown-value-to-a-choice-key-in-pgfkeys}{solution}
+%    \begin{macrocode}
+\pgfkeys{
+  /metropolis/outer/footer/.cd,
+    .is choice,
+    none/.code=\setbeamertemplate{frame footer}[none],
+    custom/.code=\setbeamertemplate{frame footer}[custom]{#1},
+    custom/.default=\insertsection
+}
+%    \end{macrocode}
+% \end{macro}
+%
 % \begin{macro}{numbering}
 % This option controls the page numbering.
 %    \begin{macrocode}
@@ -158,6 +177,11 @@
 % fraction of the total frames.
 %
 %    \begin{macrocode}
+\defbeamertemplate{frame footer}{none}{}
+\defbeamertemplate{frame footer}{custom}[1]{ #1 }
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \defbeamertemplate{frame numbering}{none}{}
 \defbeamertemplate{frame numbering}{counter}{\insertframenumber}
 \defbeamertemplate{frame numbering}{fraction}{
@@ -169,8 +193,10 @@
 \defbeamertemplate{headline}{plain}{}
 \defbeamertemplate{footline}{plain}{%
   \begin{beamercolorbox}[wd=\textwidth, sep=3ex]{footline}%
-    \hfill%
     \usebeamerfont{page number in head/foot}%
+    \makebox[0pt][l]{}
+    \usebeamertemplate*{frame footer}
+    \hfill%
     \usebeamertemplate*{frame numbering}
   \end{beamercolorbox}%
 }

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -43,26 +43,6 @@
 %
 % \subsubsection{Options}
 %
-% \begin{macro}{footer}
-% This option controls the page left footer text, using the
-% command
-% \setbeamertemplate{frame footer}{My custom footer}
-% but it can also be set with the command
-% \metroset{footer={custom=Some text}}
-% where, if no text is specified, i.e. doing
-% \metroset{footer={custom}}
-% it will show the section name.
-%    \begin{macrocode}
-\pgfkeys{
-  /metropolis/outer/footer/.cd,
-    .is choice,
-    none/.code=\setbeamertemplate{frame footer}[none],
-    custom/.code=\setbeamertemplate{frame footer}[custom]{#1},
-    custom/.default=\insertsection
-}
-%    \end{macrocode}
-% \end{macro}
-%
 % \begin{macro}{numbering}
 % This option controls the page numbering.
 %    \begin{macrocode}


### PR DESCRIPTION
I added an option to write a footer to the bottom left part of the frames (it is empty by default). I did it because it is sometimes useful to show the name of a conference, a logo or something similar