### PR TITLE
Move titleformat options to font theme (and other tidying)

### DIFF
--- a/demo/demo.tex
+++ b/demo/demo.tex
@@ -65,7 +65,7 @@
 \end{frame}
 
 {
-\metroset{titleformat-frame=smallcaps}
+\metroset{titleformat frame=smallcaps}
 \begin{frame}{Small caps}
 	This frame uses the \texttt{smallcaps} titleformat.
 
@@ -76,7 +76,7 @@
 }
 
 {
-\metroset{titleformat-frame=allsmallcaps}
+\metroset{titleformat frame=allsmallcaps}
 \begin{frame}{All small caps}
 	This frame uses the \texttt{allsmallcaps} titleformat.
 
@@ -89,7 +89,7 @@
 }
 
 {
-\metroset{titleformat-frame=allcaps}
+\metroset{titleformat frame=allcaps}
 \begin{frame}{All caps}
 	This frame uses the \texttt{allcaps} titleformat.
 

--- a/demo/demo.tex
+++ b/demo/demo.tex
@@ -65,7 +65,7 @@
 \end{frame}
 
 {
-\metroset{titleformat frame=smallcaps}
+\metroset{titleformat-frame=smallcaps}
 \begin{frame}{Small caps}
 	This frame uses the \texttt{smallcaps} titleformat.
 
@@ -76,7 +76,7 @@
 }
 
 {
-\metroset{titleformat frame=allsmallcaps}
+\metroset{titleformat-frame=allsmallcaps}
 \begin{frame}{All small caps}
 	This frame uses the \texttt{allsmallcaps} titleformat.
 
@@ -89,7 +89,7 @@
 }
 
 {
-\metroset{titleformat frame=allcaps}
+\metroset{titleformat-frame=allcaps}
 \begin{frame}{All caps}
 	This frame uses the \texttt{allcaps} titleformat.
 

--- a/doc/metropolistheme.dtx
+++ b/doc/metropolistheme.dtx
@@ -37,7 +37,7 @@
     \suppressfontnotfounderror=0%
   }
 
-  \newcommand{\iffontsexist}[3]{%
+  \newcommand{\iffontsavailable}[3]{%
     \setcounter{fontsnotfound}{0}%
     \expandafter\forcsvlist\expandafter%
     \checkfont\expandafter{#1}%
@@ -47,13 +47,13 @@
       #3%
     \fi%
   }
-  \iffontsexist{Fira Sans Light,%
+  \iffontsavailable{Fira Sans Light,%
                 Fira Sans Light Italic,%
                 Fira Sans,%
                 Fira Sans Italic}{%
     \setmainfont[BoldFont={Fira Sans}]{Fira Sans Light}%
   }{%
-    \iffontsexist{Fira Sans Light OT,%
+    \iffontsavailable{Fira Sans Light OT,%
                   Fira Sans Light Italic OT,%
                   Fira Sans OT,%
                   Fira Sans Italic OT}{%
@@ -65,10 +65,10 @@
       }
     }
   }
-  \iffontsexist{Fira Mono, Fira Mono Bold}{%
+  \iffontsavailable{Fira Mono, Fira Mono Bold}{%
     \setmonofont{Fira Mono}%
   }{%
-    \iffontsexist{Fira Mono OT, Fira Mono Bold OT}{%
+    \iffontsavailable{Fira Mono OT, Fira Mono Bold OT}{%
       \setmonofont{Fira Mono OT}%
     }{%
       \typeout{%

--- a/doc/metropolistheme.dtx
+++ b/doc/metropolistheme.dtx
@@ -154,13 +154,15 @@
 \maketitle
 \tableofcontents
 
+
+
+
 \section{Introduction}
 
 Beamer is an awesome way to make presentations with LaTeX, but its theme
 selection is surprisingly sparse. The stock themes share an aesthetic that is
-now overused and can be a little cluttered, and the few distinctive custom
-themes available are often specialized for a particular corporate or
-institutional brand.
+can be a little cluttered, and the few distinctive custom themes available are
+often specialized for a particular corporate or institutional brand.
 
 The goal of \themename is to provide a simple, modern Beamer theme suitable
 for anyone to use. It tries to minimize noise and maximize space for content;
@@ -182,24 +184,29 @@ the theme even better, please get in touch there. The
 {full list of contributors} already contains over a dozen names!
 
 
+
+
 \section{Getting Started}
 
 \subsection{Installing from CTAN}
+
 For the regular user it is recommended to install \themename from
 \href{https://www.ctan.org}{CTAN}. In case you keep your \TeX\ distribution
-up-to-date, chances are good that \themename is already installed. If it is not,
-you need to update your packages. For  \TeX\ Live (or Mac\TeX\ on OS X) the
-following command updates all packages.
+up-to-date, chances are good that \themename is already installed. If it is
+not, you need to update your packages. For  \TeX\ Live (or Mac\TeX\ on OS X)
+the following command updates all packages.
 
 \begin{lstlisting}
 sudo tlmgr update --all
 \end{lstlisting}
 
-For any other distribution please refer to its documentation on how to update your
-packages.
+For any other distribution please refer to its documentation on how to update
+your packages.
 
-To get the most out of the theme you should also install the |Fira| fonts. Yet this
-is not mandatory. \themename also works with the standard fonts.
+To get the most out of the theme you should also install the |Fira| fonts.
+Yet this is not mandatory. \themename also works with the standard fonts.
+
+
 
 \subsection{Installing from GitHub}
 
@@ -237,10 +244,14 @@ options for advanced users:
   \item[|make ctan|] creates a package for CTAN distribution.
 \end{description}
 
+
+
 \subsection{Installing the Debian Package}
 As an alternative users of Debian or Ubuntu can also install this
 \href{https://launchpad.net/\%7Eedd/+archive/ubuntu/misc/+files/latex-mtheme_0.1.0vidid1_all.deb}{.deb package}
 containing the theme files as well as the Fira Sans font files.
+
+
 
 \subsection{A Minimal Example}
 
@@ -264,19 +275,32 @@ The following code shows a minimal example of a Beamer presentation using
 \end{lstlisting}
 
 
+
 \subsection{Dependencies}
 
-\begin{itemize}
-  \item TikZ
-  \item XeLaTeX or LuaTeX
-  \item \href{https://github.com/mozilla/Fira}{Fira Sans} and Mono font
-\end{itemize}
+\themename depends on the |beamer| class and the following standard packages:
+\begin{multicols}{3}
+  \begin{itemize}
+    \item |tikz|
+    \item |pgfopts|
+    \item |etoolbox|
+    \item |calc|
+    \item |ifxetex|
+    \item |ifluatex|
+  \end{itemize}
+\end{multicols}
 
-The |Fira Sans| font is not a hard dependency. \themename will try to load the
-font and use it if it is installed, but if not it will just use the standard
-font. Depending on the Linux distribution, the packaged name of |Fira Sans|
-might be |Fira Sans OT| instead of |Fira Sans|. \themename will check for this
-name too.
+For best results, we recommend installing the fonts
+\href{https://github.com/mozilla/Fira}{|Fira Sans|} and |Fira Mono|
+and compiling with \themename using Xe\LaTeX{} or Lua\TeX{}.
+These are optional dependencies; \themename is compatible with (e.g.)
+pdf\LaTeX{} and will fall back to standard fonts if |Fira Sans| or |Fira Mono|
+is not installed.
+
+The packaged name of |Fira Sans| is |Fira Sans OT| in some Linux
+distributions; this case is automatically handled by \themename.
+
+
 
 \subsection{Pandoc}
 
@@ -291,110 +315,96 @@ $ pandoc -t beamer --latex-engine=xelatex -V theme:metropolis -o output.pdf inpu
 
 
 \section{Customization}
+
 \subsection{Package options}
-The theme provides a number of options. The options use a key=value interface.
-So every option is controlled by a key its value. To use an option you can
-either provide a comma separated list of options when invoking
-\textsc{metropolis} in the preamble of the presentation.
+
+The theme provides a number of options, which can be set using a key=value
+interface. The primary way to set options is to provide a comma-separated list
+of option-value pairs when loading \themename in the preamble:
 \begin{lstlisting}
-\usetheme[<key=value list>]{metropolis}
+\usetheme[option1=value1, option2=value2, ...]{metropolis}
 \end{lstlisting}
-Or you can set them at any time with the |\metroset| macro.
+
+Options can be changed at any time --- even mid-presentation! --- with the
+|\metroset| macro.
 \begin{lstlisting}
-\metroset{<key=value list>}
+\metroset{option1=newvalue1, option2=newvalue2, ...}
 \end{lstlisting}
-To set an option on a specific sub-package only you have to add the
-corresponding prefix (inner, outer, color), e.g.
-\begin{lstlisting}
-\metroset{inner/block=fill}
-\end{lstlisting}
+
 The list of options is structured as shown in the following example.
 
-\DescribeOption{key}{list of possible values}{default value}{
+\DescribeOption{option key}{list of possible values}{default}{
   A short description of the option.
 }
 
-Although the options are grouped into the corresponding packages every option
-can and in most cases should be set on the main theme directly. If an option
-is listed in multiple sub-packages, setting it on the main theme will set the
-option on every sub-package accordingly.
 
 \subsubsection{Main theme}
 \DescribeOption{titleformat}%
                {regular, smallcaps, allsmallcaps, allcaps}
                {regular}{
-  Shortcut option to change the titleformat of all titles together. Please
-  refer to section \ref{sec:titleformats} for known issues.
+  Changes the format of titles, subtitles, section titles, frame titles, and
+  the text on standout ``plain'' frames. The available options produce
+  Regular, \textsc{SmallCaps}, \textsc{\MakeLowercase{AllSmallCaps}}, or
+  \MakeUppercase{AllCaps} titles. Please refer to
+  Section~\ref{sec:titleformats} for known issues with these options.
 }
 
-\DescribeOption{titleformat plain}%
+\DescribeOption{titleformat-plain}%
                {regular, smallcaps, allsmallcaps, allcaps}%
                {regular}{
-  Control the titleformat of the plain title. Please refer to section
-  \ref{sec:titleformats} for known issues.
+  Changes the format of standout ``plain'' frames (see |titleformat|, above).
 }
+
 
 \subsubsection{Inner theme}
 \DescribeOption{block}{transparent, fill}{transparent}{
-  This option controls the block background. It can either be filled with a
-  light grey or be transparent.
+  Optionally adds a light grey background to block environments like |theorem|
+  and |example|.
 }
 
 \DescribeOption{sectionpage}{none, simple, progressbar}{progressbar}{
-  Disable section pages at all, typeset centered section title or add a thin
-  progress bar below the centered section title.
-}
-
-\DescribeOption{titleformat title}%
-               {regular, smallcaps, allsmallcaps, allcaps}%
-               {regular}{
-  Control the titleformat of the title. Please refer to section
-  \ref{sec:titleformats} for known issues.
-}
-
-\DescribeOption{titleformat subtitle}%
-               {regular, smallcaps, allsmallcaps, allcaps}%
-               {regular}{
-  Control the titleformat of the subtitle. Please refer to section
-  \ref{sec:titleformats} for known issues.
-}
-
-\DescribeOption{titleformat section}%
-               {regular, smallcaps, allsmallcaps, allcaps}%
-               {regular}{
-  Control the titleformat of the section title. Please refer to section
-  \ref{sec:titleformats} for known issues.
+  Adds a slide at the start of each section (|simple|) with an optional thin
+  progress bar below the section title (|progressbar|). The |none| option
+  disables the section page.
 }
 
 \subsubsection{Outer theme}
 \DescribeOption{numbering}{none, counter, fraction}{counter}{
-  In the bottom right corner of each frame the current frame number is
-  displayed. This can be disabled or the total framenumber can be added
-  additionally.
+  Controls whether the frame number at the bottom right of each slide is
+  omitted (|none|), shown (|counter|) or displayed as a fraction of the total
+  number of frames (|fraction|).
 }
 
 \DescribeOption{progressbar}{none, head, frametitle, foot}{none}{
-  Adds a progress bar to the top of each frame (|head|), the bottom of each
-  frame (|foot|), or directly below each frame title (|frametitle|).
-}
-
-\DescribeOption{titleformat frame}%
-               {regular, smallcaps, allsmallcaps, allcaps}%
-               {regular}{
-  Control the titleformat of the frame title. Please refer to section
-  \ref{sec:titleformats} for known issues.
+  Optionally adds a progress bar to the top of each frame (|head|),
+  the bottom of each frame (|foot|), or directly below each frame title
+  (|frametitle|).
 }
 
 \subsubsection{Color theme}
 \DescribeOption{block}{transparent, fill}{transparent}{
-  This option controls the block background. It can either be filled with a
-  light grey or be transparent.
+  Optionally adds a light grey background to block environments like |theorem|
+  and |example|.
 }
 
 \DescribeOption{background}{dark, light}{light}{
-  This option defines whether the background shall be dark and the foreground
-  be light or vice versa.
+  Provides the option to have a dark background and light foreground instead
+  of the reverse.
 }
+
+\subsubsection{Font theme}
+
+\DescribeMacro{titleformat-title}
+\DescribeMacro{titleformat-subtitle}
+\DescribeMacro{titeformat-section}
+\DescribeOption{titleformat-frame}%
+               {regular, smallcaps, allsmallcaps, allcaps}%
+               {regular}{
+  Individually controls the format of titles, subtitles, section titles, and
+  frame titles (see |titleformat|, above).
+}
+
+
 
 \subsection{Color Customization}
 
@@ -422,12 +432,13 @@ of \themename specific colors, which can also be redefined to your liking.
 \setbeamercolor{progress bar in section page}{ ... }
 \end{lstlisting}
 
+
+
 \subsection{Font Customization}
 
-The default font for \themename is |Fira|. Yet this can be easily changed using
+The default font for \themename is |Fira|. This can be easily changed using
 the standard font selection commands of the \textsf{fontspec} package. So if
-you for example prefer the \href{http://font.ubuntu.com}{|Ubuntu|} font family
-just add the following two commands after loading the \themename theme.
+you prefer, for example, the \href{http://font.ubuntu.com}{|Ubuntu|} font family, just add the following two commands after loading the \themename theme.
 
 \begin{lstlisting}
 \setsansfont{Ubuntu}
@@ -438,8 +449,8 @@ just add the following two commands after loading the \themename theme.
 \subsubsection{Old style figures}
 
 The regular \textsf{fontspec} mechanism for changing glyph appearance applies
-also to this theme. In case you want to have old style figures in the text but
-regular lined figures for math, you have to add the following to your preamble:
+also to this theme. If you want to have old style figures in the text but
+regular lined figures for math, you could add the following to your preamble:
 
 \begin{lstlisting}
 \usefonttheme{professionalfonts}   % required for mathspec
@@ -477,16 +488,21 @@ based on Tol's work. Use the |mlineplot| key to plot line data and |mbarplot|
 or horizontal |mbarplot| to plot bar charts.
 
 
+
+
 \section{Known Issues}
 
-\subsection{Titleformats}
+\subsection{Title formats}
 \label{sec:titleformats}
-If you want to use either |smallcaps| or |allsmallcaps| be aware that not
-every font supports small caps. So make sure the font you are using does.
 
-|allsmallcaps| and |allcaps| are quite nice from an aesthetic point of view,
-but they introduce some issues by using |\MakeLowercase| and |\MakeUppercase|,
-respectively.
+Be aware that not every font supports small caps, so the |smallcaps| or
+|allsmallcaps| options may not work if you use a font other than |Fira Sans|.
+In particular, the Computer Modern sans-serif typeface, which is used when
+\themename is compiled with pdf\LaTeX, does not have a small-caps variant.
+
+The title format options |allsmallcaps| and |allcaps| are quite nice from an
+aesthetic point of view, but their use of |\MakeLowercase| and
+|\MakeUppercase| can cause unexpected problems. For example:
 
 \begin{itemize}
     \item Some commands, like |\\|, do not work inside |\MakeLowercase| and
@@ -505,18 +521,26 @@ respectively.
     \href{https://github.com/matze/mtheme/issues/153}{\#153})
 \end{itemize}
 
+The |allsmallcaps| and |allcaps| options are safe to use if your titles contain
+only alphabetic characters and do not require the expansion of any macros.
+
+
+
 \subsection{Plain Frame}
 The |\plain| command does not work if you override the \themename color theme
 with the default beamer color theme |fly|.
 
+
+
+
 \section{License}
 
-The theme itself is licensed under a
+\themename is licensed under a
 \href{http://creativecommons.org/licenses/by-sa/4.0/}{Creative Commons
-Attribution-ShareAlike 4.0 International License}. This means that if you change
-the theme and re-distribute it, you must retain the copyright notice header and
-license it under the same CC-BY-SA license. This does not affect the
-presentation that you create with the theme.
+Attribution-ShareAlike 4.0 International License}.
+This means that if you change the theme and re-distribute it, you must retain
+the copyright notice header and license it under the same CC-BY-SA license.
+This does not affect any presentations that you create with the theme.
 
 
 

--- a/doc/metropolistheme.dtx
+++ b/doc/metropolistheme.dtx
@@ -147,7 +147,7 @@
 \GetFileInfo{beamerthememetropolis.dtx}
 \title{Modern Beamer Presentations with the \themename package}
 \author{Matthias Vogelgesang \\ \url{matthias.vogelgesang@gmail.com}}
-\date{v1.0 -- 2015/12/04}
+\date{v1.1 --- 2016/02/06}
 
 \begin{document}
 

--- a/source/beamercolorthememetropolis.dtx
+++ b/source/beamercolorthememetropolis.dtx
@@ -27,7 +27,7 @@
 %<*package>
 % ------------------------------------------------------------------------- \fi
 %
-% \subsection{\textsc{metropolis} color theme}
+% \subsection{\themename color theme}
 %
 % Load required packages.
 %    \begin{macrocode}
@@ -90,8 +90,8 @@
 %
 % \subsubsection{Base styles}
 %
-% All colors in the \textsc{metropolis} theme are derived from the definitions
-% of |normal text|, |alerted text|, and |example text|.
+% All colors in \themename are derived from the definitions of |normal text|,
+% |alerted text|, and |example text|.
 %
 %    \begin{macrocode}
 \newcommand{\@metropolis@colors@dark}{
@@ -133,8 +133,8 @@
 %    \end{macrocode}
 %
 % The “primary” palette should be used for the most important navigational
-% elements, and possibly of other elements. The \textsc{metropolis} theme uses
-% it for frame titles and slides.
+% elements, and possibly of other elements. \themename uses it for frame
+% titles and slides.
 %
 %    \begin{macrocode}
 \setbeamercolor{palette primary}{%
@@ -148,7 +148,7 @@
 }
 %    \end{macrocode}
 %
-% The \textsc{metropolis} inner or outer themes optionally display progress
+% The \themename inner or outer themes optionally display progress
 % bars in various locations. Their color is set by |progress bar| but the two
 % different kinds can be customized separately. The horizontal rule on the
 % title page is also set based on the progress bar color and can be customized

--- a/source/beamercolorthememetropolis.dtx
+++ b/source/beamercolorthememetropolis.dtx
@@ -29,7 +29,9 @@
 %
 % \subsection{\themename color theme}
 %
-% Load required packages.
+%
+%
+% \subsubsection{Package dependencies}
 %    \begin{macrocode}
 \RequirePackage{pgfopts}
 %    \end{macrocode}
@@ -39,7 +41,7 @@
 % \subsubsection{Options}
 %
 % \begin{macro}{block}
-% This option controls whether the blocks are filled or transparent.
+%    Controls whether block environments are filled or transparent.
 %    \begin{macrocode}
 \pgfkeys{
   /metropolis/color/block/.cd,
@@ -51,8 +53,8 @@
 % \end{macro}
 %
 % \begin{macro}{colors}
-% Defines whether the background shall be dark and the foreground be light or
-% vice versa
+%    Provides the option to have a dark background and light foreground instead
+%    of the reverse.
 %    \begin{macrocode}
 \pgfkeys{
   /metropolis/color/background/.cd,
@@ -64,7 +66,7 @@
 % \end{macro}
 %
 % \begin{macro}{\metropolis@color@setdefaults}
-% Set default values for color theme options.
+%    Sets default values for color theme options.
 %    \begin{macrocode}
 \newcommand{\metropolis@color@setdefaults}{
   \pgfkeys{/metropolis/color/.cd,

--- a/source/beamercolorthememetropolis.dtx
+++ b/source/beamercolorthememetropolis.dtx
@@ -13,7 +13,7 @@
 %<driver> \ProvidesFile{beamercolorthememetropolis.dtx}
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthememetropolis}[2015/12/04 Metropolis color theme]
+\ProvidesPackage{beamercolorthememetropolis}[2016/02/06 Metropolis color theme]
 %</package>
 %<driver> \documentclass{ltxdoc}
 %<driver> \usepackage{beamercolorthememetropolis}

--- a/source/beamercolorthememetropolis.dtx
+++ b/source/beamercolorthememetropolis.dtx
@@ -44,8 +44,8 @@
 \pgfkeys{
   /metropolis/color/block/.cd,
     .is choice,
-    transparent/.code=\@metropolis@block@transparent,
-    fill/.code=\@metropolis@block@fill,
+    transparent/.code=\metropolis@block@transparent,
+    fill/.code=\metropolis@block@fill,
 }
 %    \end{macrocode}
 % \end{macro}
@@ -57,16 +57,16 @@
 \pgfkeys{
   /metropolis/color/background/.cd,
     .is choice,
-    dark/.code=\@metropolis@colors@dark,
-    light/.code=\@metropolis@colors@light,
+    dark/.code=\metropolis@colors@dark,
+    light/.code=\metropolis@colors@light,
 }
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\@metropolis@color@setdefaults}
+% \begin{macro}{\metropolis@color@setdefaults}
 % Set default values for color theme options.
 %    \begin{macrocode}
-\newcommand{\@metropolis@color@setdefaults}{
+\newcommand{\metropolis@color@setdefaults}{
   \pgfkeys{/metropolis/color/.cd,
     background=light,
     block=transparent,
@@ -94,13 +94,13 @@
 % |alerted text|, and |example text|.
 %
 %    \begin{macrocode}
-\newcommand{\@metropolis@colors@dark}{
+\newcommand{\metropolis@colors@dark}{
   \setbeamercolor{normal text}{%
     fg=black!2,
     bg=mDarkTeal
   }
 }
-\newcommand{\@metropolis@colors@light}{
+\newcommand{\metropolis@colors@light}{
   \setbeamercolor{normal text}{%
     fg=mDarkTeal,
     bg=black!2
@@ -177,10 +177,10 @@
 % Blocks
 %
 %    \begin{macrocode}
-\newcommand{\@metropolis@block@transparent}{
+\newcommand{\metropolis@block@transparent}{
   \setbeamercolor{block title}{use=normal text, parent=normal text}
 }
-\newcommand{\@metropolis@block@fill}{
+\newcommand{\metropolis@block@fill}{
   \setbeamercolor{block title}{%
     use=normal text,
     fg=normal text.fg,
@@ -215,7 +215,7 @@
 % Process package options
 %
 %    \begin{macrocode}
-\@metropolis@color@setdefaults
+\metropolis@color@setdefaults
 \ProcessPgfPackageOptions{/metropolis/color}
 %    \end{macrocode}
 %

--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -26,8 +26,8 @@
 % \iffalse
 %<*package>
 % ------------------------------------------------------------------------- \fi
-% \subsection{\textsc{metropolis} font theme}
 %
+% \subsection{\themename font theme}
 %
 % Load required packages.
 %    \begin{macrocode}

--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -174,11 +174,11 @@
 %
 % \subsubsection{Title format options}
 %
-% \begin{macro}{titleformat-title}
+% \begin{macro}{titleformat title}
 %    Controls the format of the title.
 %    \begin{macrocode}
 \pgfkeys{
-  /metropolis/font/titleformat-title/.cd,
+  /metropolis/font/titleformat title/.cd,
     .is choice,
     regular/.code={%
       \let\metropolis@titleformat\@empty%
@@ -192,25 +192,25 @@
       \let\metropolis@titleformat\lowercase%
       \setbeamerfont{title}{shape=\scshape}%
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-title=allsmallcaps can lead to problems%
+        Be aware that titleformat title=allsmallcaps can lead to problems%
       }
     },
     allcaps/.code={%
       \let\metropolis@titleformat\uppercase%
       \setbeamerfont{title}{shape=\normalfont}
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-title=allcaps can lead to problems%
+        Be aware that titleformat title=allcaps can lead to problems%
       }
     },
 }
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{titleformat-subtitle}
+% \begin{macro}{titleformat subtitle}
 %    Control the format of the subtitle.
 %    \begin{macrocode}
 \pgfkeys{
-  /metropolis/font/titleformat-subtitle/.cd,
+  /metropolis/font/titleformat subtitle/.cd,
     .is choice,
     regular/.code={%
       \let\metropolis@subtitleformat\@empty%
@@ -224,25 +224,25 @@
       \let\metropolis@subtitleformat\lowercase%
       \setbeamerfont{subtitle}{shape=\scshape}%
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-subtitle=allsmallcaps can lead to problems%
+        Be aware that titleformat subtitle=allsmallcaps can lead to problems%
       }
     },
     allcaps/.code={%
       \let\metropolis@subtitleformat\uppercase%
       \setbeamerfont{subtitle}{shape=\normalfont}%
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-subtitle=allcaps can lead to problems%
+        Be aware that titleformat subtitle=allcaps can lead to problems%
       }
     },
 }
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{titleformat-section}
+% \begin{macro}{titleformat section}
 %    Controls the format of the section title.
 %    \begin{macrocode}
 \pgfkeys{
-  /metropolis/font/titleformat-section/.cd,
+  /metropolis/font/titleformat section/.cd,
     .is choice,
     regular/.code={%
       \let\metropolis@sectiontitleformat\@empty%
@@ -256,14 +256,14 @@
       \let\metropolis@sectiontitleformat\MakeLowercase%
       \setbeamerfont{section title}{shape=\scshape}%
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-section=allsmallcaps can lead to problems%
+        Be aware that titleformat section=allsmallcaps can lead to problems%
       }
     },
     allcaps/.code={%
       \let\metropolis@sectiontitleformat\MakeUppercase%
       \setbeamerfont{section title}{shape=\normalfont}%
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-section=allcaps can lead to problems%
+        Be aware that titleformat section=allcaps can lead to problems%
       }
     },
 }
@@ -274,7 +274,7 @@
 %    Control the format of the frame title.
 %    \begin{macrocode}
 \pgfkeys{
-  /metropolis/font/titleformat-frame/.cd,
+  /metropolis/font/titleformat frame/.cd,
     .is choice,
     regular/.code={%
       \let\metropolis@frametitleformat\@empty%
@@ -288,16 +288,30 @@
       \let\metropolis@frametitleformat\MakeLowercase%
       \setbeamerfont{frametitle}{shape=\scshape}%
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-frame=allsmallcaps can lead to problems%
+        Be aware that titleformat frame=allsmallcaps can lead to problems%
       }
     },
     allcaps/.code={%
       \let\metropolis@frametitleformat\MakeUppercase%
       \setbeamerfont{frametitle}{shape=\normalfont}
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-frame=allcaps can lead to problems%
+        Be aware that titleformat frame=allcaps can lead to problems%
       }
     },
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{titleformat aliases}
+%    Allows |titleformat title| et al. to be used in the |\usetheme|
+%    declaration, where \LaTeX{} automatically removes all spaces.
+%    \begin{macrocode}
+\pgfkeys{
+  /metropolis/font/.cd,
+  titleformattitle/.code=\pgfkeysalso{titleformat title=#1},
+  titleformatsubtitle/.code=\pgfkeysalso{titleformat subtitle=#1},
+  titleformatsection/.code=\pgfkeysalso{titleformat section=#1},
+  titleformatframe/.code=\pgfkeysalso{titleformat frame=#1},
 }
 %    \end{macrocode}
 % \end{macro}
@@ -307,10 +321,10 @@
 %    \begin{macrocode}
 \newcommand{\metropolis@font@setdefaults}{
   \pgfkeys{/metropolis/font/.cd,
-    titleformat-title=regular,
-    titleformat-subtitle=regular,
-    titleformat-section=regular,
-    titleformat-frame=regular,
+    titleformat title=regular,
+    titleformat subtitle=regular,
+    titleformat section=regular,
+    titleformat frame=regular,
   }
 }
 %    \end{macrocode}

--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -34,6 +34,7 @@
 \RequirePackage{etoolbox}
 \RequirePackage{ifxetex}
 \RequirePackage{ifluatex}
+\RequirePackage{pgfopts}
 %    \end{macrocode}
 %
 % \subsubsection{Load Fira font}
@@ -159,6 +160,221 @@
                                         series=\normalfont}
 %    \end{macrocode}
 %
+%
+%
+% \subsubsection{Title format options}
+%
+% \begin{macro}{titleformat-title}
+%    Controls the format of the title.
+%    \begin{macrocode}
+\pgfkeys{
+  /metropolis/font/titleformat-title/.cd,
+    .is choice,
+    regular/.code={%
+      \let\metropolis@titleformat\@empty%
+      \setbeamerfont{title}{shape=\normalfont}%
+    },
+    smallcaps/.code={%
+      \let\metropolis@titleformat\@empty%
+      \setbeamerfont{title}{shape=\scshape}%
+    },
+    allsmallcaps/.code={%
+      \let\metropolis@titleformat\lowercase%
+      \setbeamerfont{title}{shape=\scshape}%
+      \PackageWarning{beamerthememetropolis}{%
+        Be aware that titleformat-title=allsmallcaps can lead to problems%
+      }
+    },
+    allcaps/.code={%
+      \let\metropolis@titleformat\uppercase%
+      \setbeamerfont{title}{shape=\normalfont}
+      \PackageWarning{beamerthememetropolis}{%
+        Be aware that titleformat-title=allcaps can lead to problems%
+      }
+    },
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{titleformat-subtitle}
+%    Control the format of the subtitle.
+%    \begin{macrocode}
+\pgfkeys{
+  /metropolis/font/titleformat-subtitle/.cd,
+    .is choice,
+    regular/.code={%
+      \let\metropolis@subtitleformat\@empty%
+      \setbeamerfont{subtitle}{shape=\normalfont}%
+    },
+    smallcaps/.code={%
+      \let\metropolis@subtitleformat\@empty%
+      \setbeamerfont{subtitle}{shape=\scshape}%
+    },
+    allsmallcaps/.code={%
+      \let\metropolis@subtitleformat\lowercase%
+      \setbeamerfont{subtitle}{shape=\scshape}%
+      \PackageWarning{beamerthememetropolis}{%
+        Be aware that titleformat-subtitle=allsmallcaps can lead to problems%
+      }
+    },
+    allcaps/.code={%
+      \let\metropolis@subtitleformat\uppercase%
+      \setbeamerfont{subtitle}{shape=\normalfont}%
+      \PackageWarning{beamerthememetropolis}{%
+        Be aware that titleformat-subtitle=allcaps can lead to problems%
+      }
+    },
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{titleformat-section}
+%    Controls the format of the section title.
+%    \begin{macrocode}
+\pgfkeys{
+  /metropolis/font/titleformat-section/.cd,
+    .is choice,
+    regular/.code={%
+      \let\metropolis@sectiontitleformat\@empty%
+      \setbeamerfont{section title}{shape=\normalfont}%
+    },
+    smallcaps/.code={%
+      \let\metropolis@sectiontitleformat\@empty%
+      \setbeamerfont{section title}{shape=\scshape}%
+    },
+    allsmallcaps/.code={%
+      \let\metropolis@sectiontitleformat\MakeLowercase%
+      \setbeamerfont{section title}{shape=\scshape}%
+      \PackageWarning{beamerthememetropolis}{%
+        Be aware that titleformat-section=allsmallcaps can lead to problems%
+      }
+    },
+    allcaps/.code={%
+      \let\metropolis@sectiontitleformat\MakeUppercase%
+      \setbeamerfont{section title}{shape=\normalfont}%
+      \PackageWarning{beamerthememetropolis}{%
+        Be aware that titleformat-section=allcaps can lead to problems%
+      }
+    },
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{frametitleformat}
+%    Control the format of the frame title.
+%    \begin{macrocode}
+\pgfkeys{
+  /metropolis/font/titleformat-frame/.cd,
+    .is choice,
+    regular/.code={%
+      \let\metropolis@frametitleformat\@empty%
+      \setbeamerfont{frametitle}{shape=\normalfont}%
+    },
+    smallcaps/.code={%
+      \let\metropolis@frametitleformat\@empty%
+      \setbeamerfont{frametitle}{shape=\scshape}%
+    },
+    allsmallcaps/.code={%
+      \let\metropolis@frametitleformat\MakeLowercase%
+      \setbeamerfont{frametitle}{shape=\scshape}%
+      \PackageWarning{beamerthememetropolis}{%
+        Be aware that titleformat-frame=allsmallcaps can lead to problems%
+      }
+    },
+    allcaps/.code={%
+      \let\metropolis@frametitleformat\MakeUppercase%
+      \setbeamerfont{frametitle}{shape=\normalfont}
+      \PackageWarning{beamerthememetropolis}{%
+        Be aware that titleformat-frame=allcaps can lead to problems%
+      }
+    },
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\metropolis@font@setdefaults}
+%    Sets default values for font theme options.
+%    \begin{macrocode}
+\newcommand{\metropolis@font@setdefaults}{
+  \pgfkeys{/metropolis/font/.cd,
+    titleformat-title=regular,
+    titleformat-subtitle=regular,
+    titleformat-section=regular,
+    titleformat-frame=regular,
+  }
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% We first define hooks to change the case format of the titles.
+%
+%    \begin{macrocode}
+\def\metropolis@titleformat#1{#1}
+\def\metropolis@subtitleformat#1{#1}
+\def\metropolis@sectiontitleformat#1{#1}
+\def\metropolis@frametitleformat#1{#1}
+%    \end{macrocode}
+%
+% To make the uppercase and lowercase macros work in the title, subtitle, etc.,
+% we have to patch the appropriate |beamer| commands that set their values.
+% This solution was suggested by Enrico Gregorio in an answer to
+% \href{http://tex.stackexchange.com/questions/112526/}{this StackExchange
+% question}.
+%
+%    \begin{macrocode}
+\patchcmd{\beamer@title}%
+  {\def\inserttitle{#2}}%
+  {\def\inserttitle{\metropolis@titleformat{#2}}}%
+  {}%
+  {\PackageError{beamerfontthememetropolis}{Patching title failed}}
+\patchcmd{\beamer@subtitle}%
+  {\def\insertsubtitle{#2}}%
+  {\def\insertsubtitle{\metropolis@subtitleformat{#2}}}%
+  {}%
+  {\PackageError{beamerfontthememetropolis}{Patching subtitle failed}}
+\patchcmd{\sectionentry}
+  {\def\insertsectionhead{#2}}
+  {\def\insertsectionhead{\metropolis@sectiontitleformat{#2}}}
+  {}
+  {\PackageError{beamerfontthememetropolis}{Patching section title failed}}
+\patchcmd{\beamer@section}
+  {\def\insertsectionhead{\hyperlink{Navigation\the\c@page}{#1}}}
+  {\def\insertsectionhead{\hyperlink{Navigation\the\c@page}{%
+    \metropolis@sectiontitleformat{#1}}}}
+  {}
+  {\PackageError{beamerfontthememetropolis}{Patching section title failed}}
+%    \end{macrocode}
+%
+% Similarly, to make the |\MakeLowercase| and |\MakeUppercase| macros work in
+% the frame title we have to patch |\beamer@@frametitle|.
+%
+%    \begin{macrocode}
+\patchcmd{\beamer@@frametitle}
+  {\beamer@ifempty{#2}{}{%
+      \gdef\insertframetitle{{#2\ifnum\beamer@autobreakcount>0\relax{}\space%
+      \usebeamertemplate*{frametitle continuation}\fi}}%
+    \gdef\beamer@frametitle{#2}%
+    \gdef\beamer@shortframetitle{#1}%
+    }}
+  {\beamer@ifempty{#2}{}{%
+      \gdef\insertframetitle{{\metropolis@frametitleformat{#2}\ifnum%
+      \beamer@autobreakcount>0\relax{}\space%
+      \usebeamertemplate*{frametitle continuation}\fi}}%
+    \gdef\beamer@frametitle{#2}%
+    \gdef\beamer@shortframetitle{#1}%
+    }}
+  {}
+  {\PackageError{beamerfontthememetropolis}{Patching frame title failed}}
+%    \end{macrocode}
+%
+%
+%
+% \subsubsection{Process package options}
+%
+%    \begin{macrocode}
+\metropolis@font@setdefaults
+\ProcessPgfPackageOptions{/metropolis/font}
+%    \end{macrocode}
 % \iffalse
 %</package>
 % \fi

--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -13,7 +13,7 @@
 %<driver> \ProvidesFile{beamerfontthememetropolis.dtx}
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthememetropolis}[2015/12/04 Metropolis font theme]
+\ProvidesPackage{beamerfontthememetropolis}[2016/02/06 Metropolis font theme]
 %</package>
 %<driver> \documentclass{ltxdoc}
 %<driver> \usepackage{beamerfontthememetropolis}

--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -65,11 +65,11 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\iffontexists}
-% Resets the |fontsnotfound| counter and calls |\checkfont| for each font in
-% the comma separated list in the first argument.
+% \begin{macro}{\iffontsavailable}
+%    Resets the |fontsnotfound| counter and calls |\checkfont| for each font in
+%    the comma separated list in the first argument.
 %    \begin{macrocode}
-  \newcommand{\iffontsexist}[3]{%
+  \newcommand{\iffontsavailable}[3]{%
     \setcounter{fontsnotfound}{0}%
     \expandafter\forcsvlist\expandafter%
     \checkfont\expandafter{#1}%
@@ -88,13 +88,13 @@
 % also fails a warning will be displayed and the standard fonts will be used.
 %
 %    \begin{macrocode}
-  \iffontsexist{Fira Sans Light,%
+  \iffontsavailable{Fira Sans Light,%
                 Fira Sans Light Italic,%
                 Fira Sans,%
                 Fira Sans Italic}{%
     \setsansfont[BoldFont={Fira Sans}]{Fira Sans Light}%
   }{%
-    \iffontsexist{Fira Sans Light OT,%
+    \iffontsavailable{Fira Sans Light OT,%
                   Fira Sans Light Italic OT,%
                   Fira Sans OT,%
                   Fira Sans Italic OT}{%
@@ -105,10 +105,10 @@
       }
     }
   }
-  \iffontsexist{Fira Mono, Fira Mono Bold}{%
+  \iffontsavailable{Fira Mono, Fira Mono Bold}{%
     \setmonofont{Fira Mono}%
   }{%
-    \iffontsexist{Fira Mono OT, Fira Mono Bold OT}{%
+    \iffontsavailable{Fira Mono OT, Fira Mono Bold OT}{%
       \setmonofont{Fira Mono OT}%
     }{%
       \PackageWarning{beamerthememetropolis}{%

--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -29,7 +29,12 @@
 %
 % \subsection{\themename font theme}
 %
-% Load required packages.
+% A |beamer| font theme sets the style of the font used in the document.
+%
+%
+%
+% \subsubsection{Package dependencies}
+%
 %    \begin{macrocode}
 \RequirePackage{etoolbox}
 \RequirePackage{ifxetex}
@@ -37,19 +42,20 @@
 \RequirePackage{pgfopts}
 %    \end{macrocode}
 %
-% \subsubsection{Load Fira font}
-% If the presentation is compiled with XeLaTeX or LuaLaTeX the fontspec package
-% will be loaded.
+%
+%
+% \subsubsection{Load Fira fonts}
+%
+% If the presentation is compiled with Xe\LaTeX{} or Lua\LaTeX{}, the fontspec
+% package is loaded and we search for the |Fira| fonts.
+%
 %    \begin{macrocode}
 \ifboolexpr{bool {xetex} or bool {luatex}}{
   \RequirePackage[no-math]{fontspec}
 %    \end{macrocode}
 %
-% To simplify the check whether the |Fira| fonts are installed, a set macros is
-% defined.
-%
 % \begin{macro}{\checkfont}
-% Checks if a font is installed and increases |fontsnotfound| counter if not.
+%    Checks if a font is installed; if not, |fontsnotfound| is increased.
 %    \begin{macrocode}
   \newcounter{fontsnotfound}
   \newcommand{\checkfont}[1]{%
@@ -82,10 +88,10 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% Using the previously defined macros it is tried to load the |Fira| fonts.
-% First the default |Fira| name will be tried. Second the |Fira| fonts with
-% the suffix OT -- used by some Linux distributions -- will be tried. If this
-% also fails a warning will be displayed and the standard fonts will be used.
+% We search for regular, italic, light, light italic, mono, and mono bold
+% fonts under the default |Fira Sans| and |Fira Mono| names. If this fails,
+% the suffix OT --- used by some Linux distributions --- will be tried. If this
+% also fails, a warning will be displayed and the standard fonts will be used.
 %
 %    \begin{macrocode}
   \iffontsavailable{Fira Sans Light,%
@@ -125,6 +131,10 @@
   }
 }
 %    \end{macrocode}
+%
+% This concludes the portion of the code which is only run when compiled with
+% Xe\LaTeX{} or Lua\LaTeX{}. The remainder of this package applies regardless
+% of the compiling engine.
 %
 %
 %

--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -40,7 +40,10 @@
 %   \item footnotes and plain text.
 % \end{itemize}
 %
-% Load required packages.
+%
+%
+% \subsubsection{Package dependencies}
+%
 %    \begin{macrocode}
 \RequirePackage{etoolbox}
 \RequirePackage{calc}

--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -27,7 +27,7 @@
 %<*package>
 % ------------------------------------------------------------------------- \fi
 %
-% \subsection{\textsc{metropolis} inner theme}
+% \subsection{\themename inner theme}
 %
 % A |beamer| inner theme dictates the style of the frame elements traditionally
 % set in the ``body'' of each slide. These include:

--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -64,11 +64,11 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{titleformat title}
+% \begin{macro}{titleformat-title}
 % Control the titleformat of the title
 %    \begin{macrocode}
 \pgfkeys{
-  /metropolis/inner/titleformat title/.cd,
+  /metropolis/inner/titleformat-title/.cd,
     .is choice,
     regular/.code={%
       \let\metropolis@titleformat\@empty%
@@ -82,25 +82,25 @@
       \let\metropolis@titleformat\MakeLowercase%
       \setbeamerfont{title}{shape=\scshape}%
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat title=allsmallcaps can lead to problems%
+        Be aware that titleformat-title=allsmallcaps can lead to problems%
       }
     },
     allcaps/.code={%
       \let\metropolis@titleformat\MakeUppercase%
       \setbeamerfont{title}{shape=\normalfont}
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat title=allcaps can lead to problems%
+        Be aware that titleformat-title=allcaps can lead to problems%
       }
     },
 }
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{titleformat subtitle}
+% \begin{macro}{titleformat-subtitle}
 % Control the titleformat of the subtitle
 %    \begin{macrocode}
 \pgfkeys{
-  /metropolis/inner/titleformat subtitle/.cd,
+  /metropolis/inner/titleformat-subtitle/.cd,
     .is choice,
     regular/.code={%
       \let\metropolis@subtitleformat\@empty%
@@ -114,25 +114,25 @@
       \let\metropolis@subtitleformat\MakeLowercase%
       \setbeamerfont{subtitle}{shape=\scshape}%
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat subtitle=allsmallcaps can lead to problems%
+        Be aware that titleformat-subtitle=allsmallcaps can lead to problems%
       }
     },
     allcaps/.code={%
       \let\metropolis@subtitleformat\MakeUppercase%
       \setbeamerfont{subtitle}{shape=\normalfont}%
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat subtitle=allcaps can lead to problems%
+        Be aware that titleformat-subtitle=allcaps can lead to problems%
       }
     },
 }
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{titleformat section}
+% \begin{macro}{titleformat-section}
 % Control the titleformat of the section title
 %    \begin{macrocode}
 \pgfkeys{
-  /metropolis/inner/titleformat section/.cd,
+  /metropolis/inner/titleformat-section/.cd,
     .is choice,
     regular/.code={%
       \let\metropolis@sectiontitleformat\@empty%
@@ -146,14 +146,14 @@
       \let\metropolis@sectiontitleformat\MakeLowercase%
       \setbeamerfont{section title}{shape=\scshape}%
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat section=allsmallcaps can lead to problems%
+        Be aware that titleformat-section=allsmallcaps can lead to problems%
       }
     },
     allcaps/.code={%
       \let\metropolis@sectiontitleformat\MakeUppercase%
       \setbeamerfont{section title}{shape=\normalfont}%
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat section=allcaps can lead to problems%
+        Be aware that titleformat-section=allcaps can lead to problems%
       }
     },
 }
@@ -180,9 +180,9 @@
   \pgfkeys{/metropolis/inner/.cd,
     sectionpage=progressbar,
     block=transparent,
-    titleformat title=regular,
-    titleformat subtitle=regular,
-    titleformat section=regular,
+    titleformat-title=regular,
+    titleformat-subtitle=regular,
+    titleformat-section=regular,
   }
 }
 %    \end{macrocode}

--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -13,7 +13,7 @@
 %<driver> \ProvidesFile{beamerinnerthememetropolis.dtx}
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthememetropolis}[2015/12/04 Metropolis inner theme]
+\ProvidesPackage{beamerinnerthememetropolis}[2016/02/06 Metropolis inner theme]
 %</package>
 %<driver> \documentclass{ltxdoc}
 %<driver> \usepackage{beamerinnerthememetropolis}

--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -58,8 +58,8 @@
 \pgfkeys{
   /metropolis/inner/block/.cd,
     .is choice,
-    transparent/.code=\setlength{\@metropolis@blockskip}{0ex},
-    fill/.code=\setlength{\@metropolis@blockskip}{1ex},
+    transparent/.code=\setlength{\metropolis@blockskip}{0ex},
+    fill/.code=\setlength{\metropolis@blockskip}{1ex},
 }
 %    \end{macrocode}
 % \end{macro}
@@ -71,22 +71,22 @@
   /metropolis/inner/titleformat title/.cd,
     .is choice,
     regular/.code={%
-      \let\@metropolis@titleformat\@empty%
+      \let\metropolis@titleformat\@empty%
       \setbeamerfont{title}{shape=\normalfont}%
     },
     smallcaps/.code={%
-      \let\@metropolis@titleformat\@empty%
+      \let\metropolis@titleformat\@empty%
       \setbeamerfont{title}{shape=\scshape}%
     },
     allsmallcaps/.code={%
-      \let\@metropolis@titleformat\MakeLowercase%
+      \let\metropolis@titleformat\MakeLowercase%
       \setbeamerfont{title}{shape=\scshape}%
       \PackageWarning{beamerthememetropolis}{%
         Be aware that titleformat title=allsmallcaps can lead to problems%
       }
     },
     allcaps/.code={%
-      \let\@metropolis@titleformat\MakeUppercase%
+      \let\metropolis@titleformat\MakeUppercase%
       \setbeamerfont{title}{shape=\normalfont}
       \PackageWarning{beamerthememetropolis}{%
         Be aware that titleformat title=allcaps can lead to problems%
@@ -103,22 +103,22 @@
   /metropolis/inner/titleformat subtitle/.cd,
     .is choice,
     regular/.code={%
-      \let\@metropolis@subtitleformat\@empty%
+      \let\metropolis@subtitleformat\@empty%
       \setbeamerfont{subtitle}{shape=\normalfont}%
     },
     smallcaps/.code={%
-      \let\@metropolis@subtitleformat\@empty%
+      \let\metropolis@subtitleformat\@empty%
       \setbeamerfont{subtitle}{shape=\scshape}%
     },
     allsmallcaps/.code={%
-      \let\@metropolis@subtitleformat\MakeLowercase%
+      \let\metropolis@subtitleformat\MakeLowercase%
       \setbeamerfont{subtitle}{shape=\scshape}%
       \PackageWarning{beamerthememetropolis}{%
         Be aware that titleformat subtitle=allsmallcaps can lead to problems%
       }
     },
     allcaps/.code={%
-      \let\@metropolis@subtitleformat\MakeUppercase%
+      \let\metropolis@subtitleformat\MakeUppercase%
       \setbeamerfont{subtitle}{shape=\normalfont}%
       \PackageWarning{beamerthememetropolis}{%
         Be aware that titleformat subtitle=allcaps can lead to problems%
@@ -135,22 +135,22 @@
   /metropolis/inner/titleformat section/.cd,
     .is choice,
     regular/.code={%
-      \let\@metropolis@sectiontitleformat\@empty%
+      \let\metropolis@sectiontitleformat\@empty%
       \setbeamerfont{section title}{shape=\normalfont}%
     },
     smallcaps/.code={%
-      \let\@metropolis@sectiontitleformat\@empty%
+      \let\metropolis@sectiontitleformat\@empty%
       \setbeamerfont{section title}{shape=\scshape}%
     },
     allsmallcaps/.code={%
-      \let\@metropolis@sectiontitleformat\MakeLowercase%
+      \let\metropolis@sectiontitleformat\MakeLowercase%
       \setbeamerfont{section title}{shape=\scshape}%
       \PackageWarning{beamerthememetropolis}{%
         Be aware that titleformat section=allsmallcaps can lead to problems%
       }
     },
     allcaps/.code={%
-      \let\@metropolis@sectiontitleformat\MakeUppercase%
+      \let\metropolis@sectiontitleformat\MakeUppercase%
       \setbeamerfont{section title}{shape=\normalfont}%
       \PackageWarning{beamerthememetropolis}{%
         Be aware that titleformat section=allcaps can lead to problems%
@@ -166,17 +166,17 @@
 \pgfkeys{
   /metropolis/inner/sectionpage/.cd,
     .is choice,
-    none/.code=\@metropolis@sectionpage@none,
-    simple/.code=\@metropolis@sectionpage@simple,
-    progressbar/.code=\@metropolis@sectionpage@progressbar,
+    none/.code=\metropolis@sectionpage@none,
+    simple/.code=\metropolis@sectionpage@simple,
+    progressbar/.code=\metropolis@sectionpage@progressbar,
 }
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\@metropolis@inner@setdefaults}
+% \begin{macro}{\metropolis@inner@setdefaults}
 % Set default values for inner theme options.
 %    \begin{macrocode}
-\newcommand{\@metropolis@inner@setdefaults}{
+\newcommand{\metropolis@inner@setdefaults}{
   \pgfkeys{/metropolis/inner/.cd,
     sectionpage=progressbar,
     block=transparent,
@@ -192,12 +192,12 @@
 %
 % \subsubsection{Title page}
 %
-% \begin{macro}{\@metropolis@titleformat}
+% \begin{macro}{\metropolis@titleformat}
 % Define hooks to change the case format of the titles.
 %    \begin{macrocode}
-\def\@metropolis@titleformat#1{#1}
-\def\@metropolis@subtitleformat#1{#1}
-\def\@metropolis@sectiontitleformat#1{#1}
+\def\metropolis@titleformat#1{#1}
+\def\metropolis@subtitleformat#1{#1}
+\def\metropolis@sectiontitleformat#1{#1}
 %    \end{macrocode}
 % \end{macro}
 %
@@ -210,13 +210,13 @@
 %    \begin{macrocode}
 \patchcmd{\sectionentry}
   {\def\insertsectionhead{#2}}
-  {\def\insertsectionhead{\@metropolis@sectiontitleformat{#2}}}
+  {\def\insertsectionhead{\metropolis@sectiontitleformat{#2}}}
   {}
   {\PackageError{beamerinnerthememetropolis}{Patching section title failed}}
 \patchcmd{\beamer@section}
   {\def\insertsectionhead{\hyperlink{Navigation\the\c@page}{#1}}}
   {\def\insertsectionhead{\hyperlink{Navigation\the\c@page}{%
-  \@metropolis@sectiontitleformat{#1}}}}
+  \metropolis@sectiontitleformat{#1}}}}
   {}
   {\PackageError{beamerinnerthememetropolis}{Patching section title failed}}
 %    \end{macrocode}
@@ -298,7 +298,7 @@
 \setbeamertemplate{title}{
   \raggedright%
   \linespread{1.0}%
-  \@metropolis@titleformat{\inserttitle}%
+  \metropolis@titleformat{\inserttitle}%
   \par%
   \vspace*{0.5em}
 }
@@ -309,7 +309,7 @@
 %   Set the subtitle on the title page.
 %    \begin{macrocode}
 \setbeamertemplate{subtitle}{
-  \@metropolis@subtitleformat{\insertsubtitle}%
+  \metropolis@subtitleformat{\insertsubtitle}%
   \par%
   \vspace*{0.5em}
 }
@@ -371,7 +371,7 @@
 %   Template for the section title slide at the beginning of each section.
 %
 %    \begin{macrocode}
-\newcommand{\@metropolis@sectionpage@none}{
+\newcommand{\metropolis@sectionpage@none}{
   \AtBeginSection{
     % intenionally empty
   }
@@ -382,7 +382,7 @@
   \usebeamerfont{section title}
   \insertsectionhead\\
 }
-\newcommand{\@metropolis@sectionpage@simple}{
+\newcommand{\metropolis@sectionpage@simple}{
   \setbeamertemplate{section page}[simple]
   \AtBeginSection{
     \ifbeamer@inframe
@@ -402,7 +402,7 @@
   \end{minipage}
   \par
 }
-\newcommand{\@metropolis@sectionpage@progressbar}{
+\newcommand{\metropolis@sectionpage@progressbar}{
   \setbeamertemplate{section page}[progressbar]
   \AtBeginSection{
     \ifbeamer@inframe
@@ -456,23 +456,23 @@
 % Regular block environment
 %
 %    \begin{macrocode}
-\newlength{\@metropolis@blockskip}
+\newlength{\metropolis@blockskip}
 \setbeamertemplate{block begin}{%
-  \setlength{\parskip}{\@metropolis@parskip}
+  \setlength{\parskip}{\metropolis@parskip}
   \vspace*{1ex}
   \begin{beamercolorbox}[%
     ht=2.4ex,
     dp=1ex,
-    leftskip=\@metropolis@blockskip,
-    rightskip=\@metropolis@blockskip]{block title}
+    leftskip=\metropolis@blockskip,
+    rightskip=\metropolis@blockskip]{block title}
       \usebeamerfont*{block title}\insertblocktitle%
   \end{beamercolorbox}%
   \vspace*{-1pt}
   \usebeamerfont{block body}%
   \begin{beamercolorbox}[%
     dp=1ex,
-    leftskip=\@metropolis@blockskip,
-    rightskip=\@metropolis@blockskip,
+    leftskip=\metropolis@blockskip,
+    rightskip=\metropolis@blockskip,
     vmode]{block body}%
 }
 \setbeamertemplate{block end}{%
@@ -485,21 +485,21 @@
 %
 %    \begin{macrocode}
 \setbeamertemplate{block alerted begin}{%
-  \setlength{\parskip}{\@metropolis@parskip}
+  \setlength{\parskip}{\metropolis@parskip}
   \vspace*{1ex}
   \begin{beamercolorbox}[%
     ht=2.4ex,
     dp=1ex,
-    leftskip=\@metropolis@blockskip,
-    rightskip=\@metropolis@blockskip]{block title alerted}
+    leftskip=\metropolis@blockskip,
+    rightskip=\metropolis@blockskip]{block title alerted}
       \usebeamerfont*{block title alerted}\insertblocktitle%
   \end{beamercolorbox}%
   \vspace*{-1pt}
   \usebeamerfont{block body alerted}%
   \begin{beamercolorbox}[%
     dp=1ex,
-    leftskip=\@metropolis@blockskip,
-    rightskip=\@metropolis@blockskip,
+    leftskip=\metropolis@blockskip,
+    rightskip=\metropolis@blockskip,
     vmode]{block body alerted}%
 }
 \setbeamertemplate{block alerted end}{%
@@ -512,21 +512,21 @@
 %
 %    \begin{macrocode}
 \setbeamertemplate{block example begin}{%
-  \setlength{\parskip}{\@metropolis@parskip}
+  \setlength{\parskip}{\metropolis@parskip}
   \vspace*{1ex}
   \begin{beamercolorbox}[%
     ht=2.4ex,
     dp=1ex,
-    leftskip=\@metropolis@blockskip,
-    rightskip=\@metropolis@blockskip]{block title example}
+    leftskip=\metropolis@blockskip,
+    rightskip=\metropolis@blockskip]{block title example}
       \usebeamerfont*{block title example}\insertblocktitle%
   \end{beamercolorbox}%
   \vspace*{-1pt}
   \usebeamerfont{block body example}%
   \begin{beamercolorbox}[%
     dp=1ex,
-    leftskip=\@metropolis@blockskip,
-    rightskip=\@metropolis@blockskip,
+    leftskip=\metropolis@blockskip,
+    rightskip=\metropolis@blockskip,
     vmode]{block body example}%
 }
 \setbeamertemplate{block example end}{%
@@ -561,9 +561,9 @@
 % \subsubsection{Text and spacing settings}
 %
 %    \begin{macrocode}
-\newlength{\@metropolis@parskip}
-\setlength{\@metropolis@parskip}{0.5em}
-\setlength{\parskip}{\@metropolis@parskip}
+\newlength{\metropolis@parskip}
+\setlength{\metropolis@parskip}{0.5em}
+\setlength{\parskip}{\metropolis@parskip}
 \linespread{1.15}
 %    \end{macrocode}
 %
@@ -587,7 +587,7 @@
 % Process package options
 %
 %    \begin{macrocode}
-\@metropolis@inner@setdefaults
+\metropolis@inner@setdefaults
 \ProcessPgfPackageOptions{/metropolis/inner}
 %    \end{macrocode}
 %

--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -64,102 +64,6 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{titleformat-title}
-% Control the titleformat of the title
-%    \begin{macrocode}
-\pgfkeys{
-  /metropolis/inner/titleformat-title/.cd,
-    .is choice,
-    regular/.code={%
-      \let\metropolis@titleformat\@empty%
-      \setbeamerfont{title}{shape=\normalfont}%
-    },
-    smallcaps/.code={%
-      \let\metropolis@titleformat\@empty%
-      \setbeamerfont{title}{shape=\scshape}%
-    },
-    allsmallcaps/.code={%
-      \let\metropolis@titleformat\MakeLowercase%
-      \setbeamerfont{title}{shape=\scshape}%
-      \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-title=allsmallcaps can lead to problems%
-      }
-    },
-    allcaps/.code={%
-      \let\metropolis@titleformat\MakeUppercase%
-      \setbeamerfont{title}{shape=\normalfont}
-      \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-title=allcaps can lead to problems%
-      }
-    },
-}
-%    \end{macrocode}
-% \end{macro}
-%
-% \begin{macro}{titleformat-subtitle}
-% Control the titleformat of the subtitle
-%    \begin{macrocode}
-\pgfkeys{
-  /metropolis/inner/titleformat-subtitle/.cd,
-    .is choice,
-    regular/.code={%
-      \let\metropolis@subtitleformat\@empty%
-      \setbeamerfont{subtitle}{shape=\normalfont}%
-    },
-    smallcaps/.code={%
-      \let\metropolis@subtitleformat\@empty%
-      \setbeamerfont{subtitle}{shape=\scshape}%
-    },
-    allsmallcaps/.code={%
-      \let\metropolis@subtitleformat\MakeLowercase%
-      \setbeamerfont{subtitle}{shape=\scshape}%
-      \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-subtitle=allsmallcaps can lead to problems%
-      }
-    },
-    allcaps/.code={%
-      \let\metropolis@subtitleformat\MakeUppercase%
-      \setbeamerfont{subtitle}{shape=\normalfont}%
-      \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-subtitle=allcaps can lead to problems%
-      }
-    },
-}
-%    \end{macrocode}
-% \end{macro}
-%
-% \begin{macro}{titleformat-section}
-% Control the titleformat of the section title
-%    \begin{macrocode}
-\pgfkeys{
-  /metropolis/inner/titleformat-section/.cd,
-    .is choice,
-    regular/.code={%
-      \let\metropolis@sectiontitleformat\@empty%
-      \setbeamerfont{section title}{shape=\normalfont}%
-    },
-    smallcaps/.code={%
-      \let\metropolis@sectiontitleformat\@empty%
-      \setbeamerfont{section title}{shape=\scshape}%
-    },
-    allsmallcaps/.code={%
-      \let\metropolis@sectiontitleformat\MakeLowercase%
-      \setbeamerfont{section title}{shape=\scshape}%
-      \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-section=allsmallcaps can lead to problems%
-      }
-    },
-    allcaps/.code={%
-      \let\metropolis@sectiontitleformat\MakeUppercase%
-      \setbeamerfont{section title}{shape=\normalfont}%
-      \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-section=allcaps can lead to problems%
-      }
-    },
-}
-%    \end{macrocode}
-% \end{macro}
-%
 % \begin{macro}{sectionpage}
 % The |sectionpage| option defines the behaviour of the sectionpage.
 %    \begin{macrocode}
@@ -180,9 +84,6 @@
   \pgfkeys{/metropolis/inner/.cd,
     sectionpage=progressbar,
     block=transparent,
-    titleformat-title=regular,
-    titleformat-subtitle=regular,
-    titleformat-section=regular,
   }
 }
 %    \end{macrocode}
@@ -191,35 +92,6 @@
 %
 %
 % \subsubsection{Title page}
-%
-% \begin{macro}{\metropolis@titleformat}
-% Define hooks to change the case format of the titles.
-%    \begin{macrocode}
-\def\metropolis@titleformat#1{#1}
-\def\metropolis@subtitleformat#1{#1}
-\def\metropolis@sectiontitleformat#1{#1}
-%    \end{macrocode}
-% \end{macro}
-%
-% To make the |\MakeLowercase| and |\MakeUppercase| macros work in the
-% sectiontitle we have to patch |\sectionentry| and |\beamer@section|. This
-% solution was suggested by Enrico Gregorio in an answer to
-% \href{http://tex.stackexchange.com/questions/112526/}{this StackExchange
-% question}.
-%
-%    \begin{macrocode}
-\patchcmd{\sectionentry}
-  {\def\insertsectionhead{#2}}
-  {\def\insertsectionhead{\metropolis@sectiontitleformat{#2}}}
-  {}
-  {\PackageError{beamerinnerthememetropolis}{Patching section title failed}}
-\patchcmd{\beamer@section}
-  {\def\insertsectionhead{\hyperlink{Navigation\the\c@page}{#1}}}
-  {\def\insertsectionhead{\hyperlink{Navigation\the\c@page}{%
-  \metropolis@sectiontitleformat{#1}}}}
-  {}
-  {\PackageError{beamerinnerthememetropolis}{Patching section title failed}}
-%    \end{macrocode}
 %
 % \begin{macro}{title page}
 % Template for the title page. Each element is only typset if it is defined
@@ -298,7 +170,7 @@
 \setbeamertemplate{title}{
   \raggedright%
   \linespread{1.0}%
-  \metropolis@titleformat{\inserttitle}%
+  \inserttitle%
   \par%
   \vspace*{0.5em}
 }
@@ -309,7 +181,7 @@
 %   Set the subtitle on the title page.
 %    \begin{macrocode}
 \setbeamertemplate{subtitle}{
-  \metropolis@subtitleformat{\insertsubtitle}%
+  \insertsubtitle%
   \par%
   \vspace*{0.5em}
 }

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -86,50 +86,6 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{frametitleformat}
-% Control the titleformat of the frame title
-%    \begin{macrocode}
-\pgfkeys{
-  /metropolis/outer/titleformat-frame/.cd,
-    .is choice,
-    regular/.code={%
-      \let\metropolis@frametitleformat\@empty%
-      \setbeamerfont{frametitle}{shape=\normalfont}%
-      \renewcommand{\metropolis@frametitlestrut}{%
-        \vphantom{ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz}%
-      }
-    },
-    smallcaps/.code={%
-      \let\metropolis@frametitleformat\@empty%
-      \setbeamerfont{frametitle}{shape=\scshape}%
-      \renewcommand{\metropolis@frametitlestrut}{%
-        \vphantom{ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz}%
-      }
-    },
-    allsmallcaps/.code={%
-      \let\metropolis@frametitleformat\MakeLowercase%
-      \setbeamerfont{frametitle}{shape=\scshape}%
-      \renewcommand{\metropolis@frametitlestrut}{%
-        \vphantom{abcdefghijklmnopqrstuvwxyz}%
-      }
-      \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-frame=allsmallcaps can lead to problems%
-      }
-    },
-    allcaps/.code={%
-      \let\metropolis@frametitleformat\MakeUppercase%
-      \setbeamerfont{frametitle}{shape=\normalfont}
-      \renewcommand{\metropolis@frametitlestrut}{%
-        \vphantom{ABCDEFGHIJKLMNOPQRSTUVWXYZ}%
-      }
-      \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-frame=allcaps can lead to problems%
-      }
-    },
-}
-%    \end{macrocode}
-% \end{macro}
-%
 % \begin{macro}{\metropolis@outer@setdefaults}
 % Set default values for outer theme options.
 %    \begin{macrocode}
@@ -137,7 +93,6 @@
   \pgfkeys{/metropolis/outer/.cd,
     numbering=counter,
     progressbar=none,
-    titleformat-frame=regular,
   }
 }
 %    \end{macrocode}%
@@ -180,45 +135,15 @@
 %
 % \subsubsection{Frametitle}
 %
-% \begin{macro}{\metropolis@frametitleformat}
-%   Define a hook to change the case format of the frame title.
-%    \begin{macrocode}
-\def\metropolis@frametitleformat#1{#1}
-%    \end{macrocode}
-% \end{macro}
-%
-% To make the |\MakeLowercase| and |\MakeUppercase| macros work in the
-% frame title we have to patch |\beamer@@frametitle|. This solution was
-% suggested by Enrico Gregorio in an answer to
-% \href{http://tex.stackexchange.com/questions/112526/}{this StackExchange
-% question}.
-%
-%    \begin{macrocode}
-\patchcmd{\beamer@@frametitle}
-  {\beamer@ifempty{#2}{}{%
-      \gdef\insertframetitle{{#2\ifnum\beamer@autobreakcount>0\relax{}\space%
-      \usebeamertemplate*{frametitle continuation}\fi}}%
-    \gdef\beamer@frametitle{#2}%
-    \gdef\beamer@shortframetitle{#1}%
-    }}
-  {\beamer@ifempty{#2}{}{%
-      \gdef\insertframetitle{{\metropolis@frametitleformat{#2}\ifnum%
-      \beamer@autobreakcount>0\relax{}\space%
-      \usebeamertemplate*{frametitle continuation}\fi}}%
-    \gdef\beamer@frametitle{#2}%
-    \gdef\beamer@shortframetitle{#1}%
-    }}
-  {}
-  {\PackageError{beamerouterthememetropolis}{Patching frame title failed}}
-%    \end{macrocode}
-%
 % \begin{macro}{frametitle}
 %
 % Templates for the frame title, which is optionally underlined with a
 % progress bar.
 %
 %    \begin{macrocode}
-\newlength{\metropolis@frametitlestrut}
+\newcommand{\metropolis@frametitlestrut}{
+  \vphantom{ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz()}%
+}
 \defbeamertemplate{frametitle}{plain}{%
   \nointerlineskip%
   \begin{beamercolorbox}[%

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -13,7 +13,7 @@
 %<driver> \ProvidesFile{beamerouterthememetropolis.dtx}
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthememetropolis}[2015/12/04 Metropolis outer theme]
+\ProvidesPackage{beamerouterthememetropolis}[2016/02/06 Metropolis outer theme]
 %</package>
 %<driver> \documentclass{ltxdoc}
 %<driver> \usepackage{beamerouterthememetropolis}

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -90,7 +90,7 @@
 % Control the titleformat of the frame title
 %    \begin{macrocode}
 \pgfkeys{
-  /metropolis/outer/titleformat frame/.cd,
+  /metropolis/outer/titleformat-frame/.cd,
     .is choice,
     regular/.code={%
       \let\metropolis@frametitleformat\@empty%
@@ -113,7 +113,7 @@
         \vphantom{abcdefghijklmnopqrstuvwxyz}%
       }
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat frame=allsmallcaps can lead to problems%
+        Be aware that titleformat-frame=allsmallcaps can lead to problems%
       }
     },
     allcaps/.code={%
@@ -123,7 +123,7 @@
         \vphantom{ABCDEFGHIJKLMNOPQRSTUVWXYZ}%
       }
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat frame=allcaps can lead to problems%
+        Be aware that titleformat-frame=allcaps can lead to problems%
       }
     },
 }
@@ -137,7 +137,7 @@
   \pgfkeys{/metropolis/outer/.cd,
     numbering=counter,
     progressbar=none,
-    titleformat frame=regular,
+    titleformat-frame=regular,
   }
 }
 %    \end{macrocode}%

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -93,23 +93,23 @@
   /metropolis/outer/titleformat frame/.cd,
     .is choice,
     regular/.code={%
-      \let\@metropolis@frametitleformat\@empty%
+      \let\metropolis@frametitleformat\@empty%
       \setbeamerfont{frametitle}{shape=\normalfont}%
-      \renewcommand{\@metropolis@frametitlestrut}{%
+      \renewcommand{\metropolis@frametitlestrut}{%
         \vphantom{ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz}%
       }
     },
     smallcaps/.code={%
-      \let\@metropolis@frametitleformat\@empty%
+      \let\metropolis@frametitleformat\@empty%
       \setbeamerfont{frametitle}{shape=\scshape}%
-      \renewcommand{\@metropolis@frametitlestrut}{%
+      \renewcommand{\metropolis@frametitlestrut}{%
         \vphantom{ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz}%
       }
     },
     allsmallcaps/.code={%
-      \let\@metropolis@frametitleformat\MakeLowercase%
+      \let\metropolis@frametitleformat\MakeLowercase%
       \setbeamerfont{frametitle}{shape=\scshape}%
-      \renewcommand{\@metropolis@frametitlestrut}{%
+      \renewcommand{\metropolis@frametitlestrut}{%
         \vphantom{abcdefghijklmnopqrstuvwxyz}%
       }
       \PackageWarning{beamerthememetropolis}{%
@@ -117,9 +117,9 @@
       }
     },
     allcaps/.code={%
-      \let\@metropolis@frametitleformat\MakeUppercase%
+      \let\metropolis@frametitleformat\MakeUppercase%
       \setbeamerfont{frametitle}{shape=\normalfont}
-      \renewcommand{\@metropolis@frametitlestrut}{%
+      \renewcommand{\metropolis@frametitlestrut}{%
         \vphantom{ABCDEFGHIJKLMNOPQRSTUVWXYZ}%
       }
       \PackageWarning{beamerthememetropolis}{%
@@ -130,10 +130,10 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\@metropolis@outer@setdefaults}
+% \begin{macro}{\metropolis@outer@setdefaults}
 % Set default values for outer theme options.
 %    \begin{macrocode}
-\newcommand{\@metropolis@outer@setdefaults}{
+\newcommand{\metropolis@outer@setdefaults}{
   \pgfkeys{/metropolis/outer/.cd,
     numbering=counter,
     progressbar=none,
@@ -180,10 +180,10 @@
 %
 % \subsubsection{Frametitle}
 %
-% \begin{macro}{\@metropolis@frametitleformat}
+% \begin{macro}{\metropolis@frametitleformat}
 %   Define a hook to change the case format of the frame title.
 %    \begin{macrocode}
-\def\@metropolis@frametitleformat#1{#1}
+\def\metropolis@frametitleformat#1{#1}
 %    \end{macrocode}
 % \end{macro}
 %
@@ -202,7 +202,7 @@
     \gdef\beamer@shortframetitle{#1}%
     }}
   {\beamer@ifempty{#2}{}{%
-      \gdef\insertframetitle{{\@metropolis@frametitleformat{#2}\ifnum%
+      \gdef\insertframetitle{{\metropolis@frametitleformat{#2}\ifnum%
       \beamer@autobreakcount>0\relax{}\space%
       \usebeamertemplate*{frametitle continuation}\fi}}%
     \gdef\beamer@frametitle{#2}%
@@ -218,14 +218,14 @@
 % progress bar.
 %
 %    \begin{macrocode}
-\newlength{\@metropolis@frametitlestrut}
+\newlength{\metropolis@frametitlestrut}
 \defbeamertemplate{frametitle}{plain}{%
   \nointerlineskip%
   \begin{beamercolorbox}[%
       wd=\paperwidth,%
       sep=1.5ex,%
     ]{frametitle}%
-  \@metropolis@frametitlestrut\insertframetitle\@metropolis@frametitlestrut%
+  \metropolis@frametitlestrut\insertframetitle\metropolis@frametitlestrut%
   \end{beamercolorbox}%
 }
 %    \end{macrocode}
@@ -257,7 +257,7 @@
 % Process package options
 %
 %    \begin{macrocode}
-\@metropolis@outer@setdefaults
+\metropolis@outer@setdefaults
 \ProcessPgfPackageOptions{/metropolis/outer}
 %    \end{macrocode}
 %

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -27,7 +27,7 @@
 %<*package>
 % ------------------------------------------------------------------------- \fi
 %
-% \subsection{\textsc{metropolis} outer theme}
+% \subsection{\themename outer theme}
 %
 % A |beamer| outer theme dictates the style of the frame elements traditionally
 % set outside the body of each slide: the head, footline, and frame title.
@@ -148,7 +148,7 @@
 % \subsubsection{Head and footline}
 %
 % All good |beamer| presentations should already remove the navigation symbols,
-% but \textsc{metropolis} removes them automatically (just in case).
+% but \themename removes them automatically (just in case).
 %
 %    \begin{macrocode}
 \setbeamertemplate{navigation symbols}{}

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -32,7 +32,10 @@
 % A |beamer| outer theme dictates the style of the frame elements traditionally
 % set outside the body of each slide: the head, footline, and frame title.
 %
-% Load required packages.
+%
+%
+% \subsubsection{Package dependencies}
+%
 %    \begin{macrocode}
 \RequirePackage{etoolbox}
 \RequirePackage{calc}
@@ -44,7 +47,7 @@
 % \subsubsection{Options}
 %
 % \begin{macro}{numbering}
-% This option controls the page numbering.
+%    Adds slide numbers to the bottom right of each slide.
 %    \begin{macrocode}
 \pgfkeys{
   /metropolis/outer/numbering/.cd,
@@ -57,7 +60,7 @@
 % \end{macro}
 %
 % \begin{macro}{progressbar}
-% This option controls the progressbar.
+%    Adds a progress bar to the top, bottom, or frametitle of each slide.
 %    \begin{macrocode}
 \pgfkeys{
   /metropolis/outer/progressbar/.cd,
@@ -87,7 +90,7 @@
 % \end{macro}
 %
 % \begin{macro}{\metropolis@outer@setdefaults}
-% Set default values for outer theme options.
+%    Sets default values for outer theme options.
 %    \begin{macrocode}
 \newcommand{\metropolis@outer@setdefaults}{
   \pgfkeys{/metropolis/outer/.cd,
@@ -109,9 +112,9 @@
 \setbeamertemplate{navigation symbols}{}
 %    \end{macrocode}
 %
-% Templates for the frame number. Can be omitted, shown or displayed as a
-% fraction of the total frames.
-%
+% \begin{macro}{frame numbering}
+%    Templates for the frame number. Can be omitted, shown or displayed as a
+%    fraction of the total frames.
 %    \begin{macrocode}
 \defbeamertemplate{frame numbering}{none}{}
 \defbeamertemplate{frame numbering}{counter}{\insertframenumber}
@@ -119,7 +122,11 @@
   \insertframenumber/\inserttotalframenumber
 }
 %    \end{macrocode}
+% \end{macro}
 %
+% \begin{macro}{headline}
+% \begin{macro}{footline}
+%    Templates for the head- and footline at the top and bottom of each frame.
 %    \begin{macrocode}
 \defbeamertemplate{headline}{plain}{}
 \defbeamertemplate{footline}{plain}{%
@@ -130,16 +137,16 @@
   \end{beamercolorbox}%
 }
 %    \end{macrocode}
+% \end{macro}
+% \end{macro}
 %
 %
 %
 % \subsubsection{Frametitle}
 %
 % \begin{macro}{frametitle}
-%
-% Templates for the frame title, which is optionally underlined with a
-% progress bar.
-%
+%    Templates for the frame title, which is optionally underlined with a
+%    progress bar.
 %    \begin{macrocode}
 \newcommand{\metropolis@frametitlestrut}{
   \vphantom{ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz()}%
@@ -157,11 +164,9 @@
 % \end{macro}
 %
 % \begin{macro}{progress bar in head/foot}
-%
-% Template for the progress bar optionally displayed below the frame title
-% on each page. Much of this code is duplicated in the inner theme's template
-% |progress bar in section page|.
-%
+%    Template for the progress bar optionally displayed below the frame title
+%    on each page. Much of this code is duplicated in the inner theme's
+%    template |progress bar in section page|.
 %    \begin{macrocode}
 \newlength{\metropolis@progressinheadfoot}
 \setbeamertemplate{progress bar in head/foot}{
@@ -179,7 +184,9 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% Process package options
+%
+%
+% \subsubsection{Process package options}
 %
 %    \begin{macrocode}
 \metropolis@outer@setdefaults

--- a/source/beamerthememetropolis.dtx
+++ b/source/beamerthememetropolis.dtx
@@ -27,10 +27,10 @@
 %<*package>
 % ------------------------------------------------------------------------- \fi
 %
-% \subsection{\textsc{metropolis} main theme}
+% \subsection{\themename parent theme}
 %
 % The primary job of this package is to load the component sub-packages of the
-% \textsc{metropolis} theme and route the theme options accordingly. It also
+% \themename theme and route the theme options accordingly. It also
 % provides some custom commands and environments for the user.
 %
 % Load the required packages.

--- a/source/beamerthememetropolis.dtx
+++ b/source/beamerthememetropolis.dtx
@@ -76,22 +76,22 @@
   /metropolis/titleformat plain/.cd,
     .is choice,
     regular/.code={%
-      \let\@metropolis@plaintitleformat\@empty%
+      \let\metropolis@plaintitleformat\@empty%
       \setbeamerfont{plain title}{shape=\normalfont}%
     },
     smallcaps/.code={%
-      \let\@metropolis@plaintitleformat\@empty%
+      \let\metropolis@plaintitleformat\@empty%
       \setbeamerfont{plain title}{shape=\scshape}%
     },
     allsmallcaps/.code={%
-      \let\@metropolis@plaintitleformat\MakeLowercase%
+      \let\metropolis@plaintitleformat\MakeLowercase%
       \setbeamerfont{plain title}{shape=\scshape}%
       \PackageWarning{beamerthememetropolis}{%
         Be aware that titleformat plain=allsmallcaps can lead to problems%
       }
     },
     allcaps/.code={%
-      \let\@metropolis@plaintitleformat\MakeUppercase%
+      \let\metropolis@plaintitleformat\MakeUppercase%
       \setbeamerfont{plain title}{shape=\normalfont}%
       \PackageWarning{beamerthememetropolis}{%
         Be aware that titleformat plain=allcaps can lead to problems%
@@ -133,7 +133,7 @@
 % Set default values for options.
 %
 %    \begin{macrocode}
-\newcommand{\@metropolis@setdefaults}{
+\newcommand{\metropolis@setdefaults}{
   \pgfkeys{/metropolis/.cd,
     titleformat plain=regular,
   }
@@ -170,17 +170,12 @@
 % We define custom commands in this package as their proper usage may depend
 % on multiple sub-packages.
 %
-% \begin{macro}{\@metropolis@plaintitleformat}
-%   Define a hook to change the case format of the plain title.
-%    \begin{macrocode}
-\def\@metropolis@plaintitleformat#1{#1}
-%    \end{macrocode}
-% \end{macro}
 %
 % \begin{macro}{\plain}
 %   Creates a plain frame with dark background, suitable for displaying images
 %   or a few words.
 %    \begin{macrocode}
+\def\metropolis@plaintitleformat#1{#1}
 \newcommand{\plain}[2][]{%
   \begingroup
     \setbeamercolor{background canvas}{
@@ -191,7 +186,7 @@
       \begin{center}
         \usebeamercolor[fg]{palette primary}
         \usebeamerfont{plain title}
-        \@metropolis@plaintitleformat{#2}
+        \metropolis@plaintitleformat{#2}
       \end{center}
     \end{frame}
   \endgroup
@@ -208,7 +203,7 @@
 % Process package options
 %
 %    \begin{macrocode}
-\@metropolis@setdefaults
+\metropolis@setdefaults
 \ProcessPgfOptions{/metropolis}
 %    \end{macrocode}
 %

--- a/source/beamerthememetropolis.dtx
+++ b/source/beamerthememetropolis.dtx
@@ -69,11 +69,11 @@
 }
 %    \end{macrocode}
 %
-% \begin{macro}{titleformat-plain}
+% \begin{macro}{titleformat plain}
 %    Controls the formatting of the text on standout ``plain'' frames.
 %    \begin{macrocode}
 \pgfkeys{
-  /metropolis/titleformat-plain/.cd,
+  /metropolis/titleformat plain/.cd,
     .is choice,
     regular/.code={%
       \let\metropolis@plaintitleformat\@empty%
@@ -87,14 +87,14 @@
       \let\metropolis@plaintitleformat\MakeLowercase%
       \setbeamerfont{plain title}{shape=\scshape}%
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-plain=allsmallcaps can lead to problems%
+        Be aware that titleformat plain=allsmallcaps can lead to problems%
       }
     },
     allcaps/.code={%
       \let\metropolis@plaintitleformat\MakeUppercase%
       \setbeamerfont{plain title}{shape=\normalfont}%
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat-plain=allcaps can lead to problems%
+        Be aware that titleformat plain=allcaps can lead to problems%
       }
     },
 }
@@ -107,11 +107,11 @@
 %    \begin{macrocode}
 \pgfkeys{
   /metropolis/titleformat/.code=\pgfkeysalso{
-      font/titleformat-title=#1,
-      font/titleformat-subtitle=#1,
-      font/titleformat-section=#1,
-      font/titleformat-frame=#1,
-      titleformat-plain=#1,
+      font/titleformat title=#1,
+      font/titleformat subtitle=#1,
+      font/titleformat section=#1,
+      font/titleformat frame=#1,
+      titleformat plain=#1,
     }
 }
 %    \end{macrocode}
@@ -136,7 +136,7 @@
 %    \begin{macrocode}
 \newcommand{\metropolis@setdefaults}{
   \pgfkeys{/metropolis/.cd,
-    titleformat-plain=regular,
+    titleformat plain=regular,
   }
 }
 %    \end{macrocode}

--- a/source/beamerthememetropolis.dtx
+++ b/source/beamerthememetropolis.dtx
@@ -69,11 +69,11 @@
 }
 %    \end{macrocode}
 %
-% \begin{macro}{titleformat plain}
 % Control the titleformat of the plain title
+% \begin{macro}{titleformat-plain}
 %    \begin{macrocode}
 \pgfkeys{
-  /metropolis/titleformat plain/.cd,
+  /metropolis/titleformat-plain/.cd,
     .is choice,
     regular/.code={%
       \let\metropolis@plaintitleformat\@empty%
@@ -87,14 +87,14 @@
       \let\metropolis@plaintitleformat\MakeLowercase%
       \setbeamerfont{plain title}{shape=\scshape}%
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat plain=allsmallcaps can lead to problems%
+        Be aware that titleformat-plain=allsmallcaps can lead to problems%
       }
     },
     allcaps/.code={%
       \let\metropolis@plaintitleformat\MakeUppercase%
       \setbeamerfont{plain title}{shape=\normalfont}%
       \PackageWarning{beamerthememetropolis}{%
-        Be aware that titleformat plain=allcaps can lead to problems%
+        Be aware that titleformat-plain=allcaps can lead to problems%
       }
     },
 }
@@ -106,11 +106,11 @@
 %    \begin{macrocode}
 \pgfkeys{
   /metropolis/titleformat/.code=\pgfkeysalso{
-      inner/titleformat title=#1,
-      inner/titleformat subtitle=#1,
-      inner/titleformat section=#1,
-      outer/titleformat frame=#1,
-      titleformat plain=#1,
+      inner/titleformat-title=#1,
+      inner/titleformat-subtitle=#1,
+      inner/titleformat-section=#1,
+      outer/titleformat-frame=#1,
+      titleformat-plain=#1,
     }
 }
 %    \end{macrocode}
@@ -135,7 +135,7 @@
 %    \begin{macrocode}
 \newcommand{\metropolis@setdefaults}{
   \pgfkeys{/metropolis/.cd,
-    titleformat plain=regular,
+    titleformat-plain=regular,
   }
 }
 %    \end{macrocode}

--- a/source/beamerthememetropolis.dtx
+++ b/source/beamerthememetropolis.dtx
@@ -33,22 +33,20 @@
 % \themename theme and route the theme options accordingly. It also
 % provides some custom commands and environments for the user.
 %
-% Load the required packages.
+%
+%
+% \subsubsection{Package dependencies}
+%
 %    \begin{macrocode}
 \RequirePackage{etoolbox}
 \RequirePackage{pgfopts}
 %    \end{macrocode}
 %
+%
+%
 % \subsubsection{Options}
 %
-% \begin{macro}{\metroset}
-% First of all we define a macro for the user to set options.
-%    \begin{macrocode}
-\newcommand{\metroset}[1]{\pgfkeys{/metropolis/.cd,#1}}
-%    \end{macrocode}
-% \end{macro}
-%
-% Then we need to pass the unknown options to the sub-packages.
+% Most options are passed off to the component sub-packages.
 %
 %    \begin{macrocode}
 \pgfkeys{/metropolis/.cd,
@@ -60,7 +58,8 @@
   },
 %    \end{macrocode}
 %
-% We have to forwarded keys that affect multiple sub-packages manually.
+% Currently, the |block| option affects two subthemes and has to be handled
+% separately.
 %
 %    \begin{macrocode}
   block/.code=\pgfkeysalso{
@@ -70,8 +69,8 @@
 }
 %    \end{macrocode}
 %
-% Control the titleformat of the plain title
 % \begin{macro}{titleformat-plain}
+%    Controls the formatting of the text on standout ``plain'' frames.
 %    \begin{macrocode}
 \pgfkeys{
   /metropolis/titleformat-plain/.cd,
@@ -103,7 +102,8 @@
 % \end{macro}
 %
 % \begin{macro}{titleformat}
-% Control the titleformat of every title type together
+%    Sets a standard format for titles, subtitles, section titles, frame
+%    titles, and the text on standout ``plain'' frames.
 %    \begin{macrocode}
 \pgfkeys{
   /metropolis/titleformat/.code=\pgfkeysalso{
@@ -147,6 +147,7 @@
 %
 % Having processed the options, we can now load the component sub-packages of
 % the theme.
+%
 %    \begin{macrocode}
 \useinnertheme{metropolis}
 \useoutertheme{metropolis}
@@ -168,13 +169,20 @@
 %
 % \subsubsection{Custom commands}
 %
-% We define custom commands in this package as their proper usage may depend
+% The parent theme defines custom commands as their proper usage may depend
 % on multiple sub-packages.
 %
+% \begin{macro}{\metroset}
+%    Allows the user to change options midway through a presentation.
+%    \begin{macrocode}
+\newcommand{\metroset}[1]{\pgfkeys{/metropolis/.cd,#1}}
+%    \end{macrocode}
+% \end{macro}
 %
 % \begin{macro}{\plain}
 %   Creates a plain frame with dark background, suitable for displaying images
-%   or a few words.
+%   or a few words. The format of the text can be set with the
+%   |titleformat plain| option.
 %    \begin{macrocode}
 \def\metropolis@plaintitleformat#1{#1}
 \newcommand{\plain}[2][]{%
@@ -201,7 +209,9 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% Process package options
+%
+%
+% \subsubsection{Process package options}
 %
 %    \begin{macrocode}
 \metropolis@setdefaults

--- a/source/beamerthememetropolis.dtx
+++ b/source/beamerthememetropolis.dtx
@@ -56,6 +56,7 @@
     /metropolis/inner,
     /metropolis/outer,
     /metropolis/color,
+    /metropolis/font,
   },
 %    \end{macrocode}
 %
@@ -106,10 +107,10 @@
 %    \begin{macrocode}
 \pgfkeys{
   /metropolis/titleformat/.code=\pgfkeysalso{
-      inner/titleformat-title=#1,
-      inner/titleformat-subtitle=#1,
-      inner/titleformat-section=#1,
-      outer/titleformat-frame=#1,
+      font/titleformat-title=#1,
+      font/titleformat-subtitle=#1,
+      font/titleformat-section=#1,
+      font/titleformat-frame=#1,
       titleformat-plain=#1,
     }
 }

--- a/source/beamerthememetropolis.dtx
+++ b/source/beamerthememetropolis.dtx
@@ -13,7 +13,7 @@
 %<driver> \ProvidesFile{beamerthememetropolis.dtx}
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthememetropolis}[2015/12/04 Metropolis Beamer theme]
+\ProvidesPackage{beamerthememetropolis}[2016/02/06 Metropolis Beamer theme]
 %</package>
 %<driver> \documentclass{ltxdoc}
 %<driver> \usepackage{beamerthememetropolis}


### PR DESCRIPTION
This PR has two primary purposes: to tidy up the documentation/code style, and to make the component sub-packages of Metropolis more useful on their own. 

1. **Moves all titleformat options to the font theme**. The `titleformat title`, `titleformat subtitle`, `titleformat section` and `titleformat frame` options should, philosophically speaking, be font options, but up until now they were split between the inner and outer themes for implementation reasons. Thanks to a new implementation of `titleformat title` and `titleformat subtitle`, this PR is able to move these options to the font theme and make them independent from the other sub-packages. 

2. **Hyphenates the titleformat options**. Although `titleformat title` et al. are valid PGF keys and work in the `\metroset` macro, the intended use case `\usetheme[titleformat title=smallcaps]{metropolis}` was broken. (It turns out that LaTeX removes all spaces when processing package options.) This PR replaces them with hyphenated versions of the same names (e.g. `titleformat-title`).

3. **Standardizes the 'namespace' of internal macros**. We were previously inconsistent over whether to name an internal macro like `\metropolis@foo` or `\@metropolis@bar`; we should stick to one or the other. Since the `beamer` source code itself uses the first style, this PR removes the leading `@` from internal macros that have it.

4. **Changes the name of `\iffontsexist`** because I kept reading it as "if font sexist". This PR changes it to the less ambiguous `\iffontsavailable`.

5. **Updates documentation**.

This PR also (rather presumptuously) increments the version to 1.1 and updates the date in each `\ProvidesPackage` declaration. Is there a roadmap for an actual 1.1 release and CTAN update?

What do you think about these changes?