### PR TITLE
Re-enable TeX ligatures in XeTeX.

### DIFF
--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -54,6 +54,14 @@
   \RequirePackage[no-math]{fontspec}
 %    \end{macrocode}
 %
+% Xe\LaTeX{} does not enable regular \TeX{} ligatures so that
+% double-quotes and dashes are not printed correctly.  The following
+% line re-enables traditional \TeX{} ligatures.
+%
+%    \begin{macrocode}
+  \defaultfontfeatures{Ligatures=TeX}
+%    \end{macrocode}
+%
 % \begin{macro}{\checkfont}
 %    Checks if a font is installed; if not, |fontsnotfound| is increased.
 %    \begin{macrocode}


### PR DESCRIPTION
The font theme on XeLaTeX does not enable the regular TeX ligatures.  This issue is discussed, for example, in 

https://tex.stackexchange.com/questions/37855/fontspec-with-helvetica-breaks-quotes

This one-line patch implements one of the solutions suggested on Stackexchange.
