### PR TITLE
Improve compatibility with other color themes

### DIFF
--- a/doc/metropolistheme.dtx
+++ b/doc/metropolistheme.dtx
@@ -523,7 +523,40 @@ only alphabetic characters and do not require the expansion of any macros.
 
 
 
+\subsection{Interactions with other color themes}
 
+\themename can be used along with any other Beamer color theme, such as
+|crane| or |seahorse|. If you wish to do this, it is usually best to include
+the \themename subpackages individually so the \themename color theme is
+never loaded. Although this will disable some features, including
+|\plain| slides, it will prevent conflicts between the \themename color theme
+and your preferred theme.
+
+For example, overriding the color theme as follows may not work as expected because |\usetheme{metropolis}| loads the \themename color theme, which
+defines a relationship between the frametitle background and the primary
+palette of the theme. Since |seahorse| assumes a different relationship
+between its palettes, the result is a grey, rather than periwinkle,
+frametitle background.
+
+\begin{lstlisting}
+\usetheme{metropolis}
+\usecolortheme{seahorse}
+\end{lstlisting}
+
+The correct colors are chosen if the \themename outer, inner, and font themes
+are loaded seperately:
+
+\begin{lstlisting}
+\useoutertheme{metropolis}
+\useinnertheme{metropolis}
+\usefonttheme{metropolis}
+\usecolortheme{seahorse}   % or your preferred color theme
+\end{lstlisting}
+
+Please note that \themename may not use all the colors defined in your
+favourite Beamer color theme. In particular, \themename does not set a
+background color for the title; this will cause issues when using color themes
+like |whale| which set a white foreground for the title.
 
 
 

--- a/doc/metropolistheme.dtx
+++ b/doc/metropolistheme.dtx
@@ -523,9 +523,6 @@ only alphabetic characters and do not require the expansion of any macros.
 
 
 
-\subsection{Plain Frame}
-The |\plain| command does not work if you override the \themename color theme
-with the default beamer color theme |fly|.
 
 
 

--- a/doc/metropolistheme.dtx
+++ b/doc/metropolistheme.dtx
@@ -357,10 +357,6 @@ The list of options is structured as shown in the following example.
 
 
 \subsubsection{Inner theme}
-\DescribeOption{block}{transparent, fill}{transparent}{
-  Optionally adds a light grey background to block environments like |theorem|
-  and |example|.
-}
 
 \DescribeOption{sectionpage}{none, simple, progressbar}{progressbar}{
   Adds a slide at the start of each section (|simple|) with an optional thin
@@ -416,6 +412,7 @@ terms of three beamer colors:
     \item |alerted text| (colored fg, should be visible against dark or light)
     \item |example text| (colored fg, should be visible against dark or light)
 \end{itemize}
+
 An easy way to customize the theme is to redefine these colors using
 
 \begin{lstlisting}

--- a/source/beamercolorthememetropolis.dtx
+++ b/source/beamercolorthememetropolis.dtx
@@ -41,7 +41,8 @@
 % \subsubsection{Options}
 %
 % \begin{macro}{block}
-%    Controls whether block environments are filled or transparent.
+%    Optionally adds a light grey background to block environments like
+%    |theorem| and |example|.
 %    \begin{macrocode}
 \pgfkeys{
   /metropolis/color/block/.cd,
@@ -176,17 +177,32 @@
 }
 %    \end{macrocode}
 %
-% Blocks
+% Block environments such as |theorem| and |example| have no background color
+% by default. The option |block=fill| sets a background color based on the
+% background and foreground of |normal text|. The option |block=transparent|
+% reverts the block environments to an empty background, which can be useful
+% if changing colors mid-presentation.
 %
 %    \begin{macrocode}
 \newcommand{\metropolis@block@transparent}{
-  \setbeamercolor{block title}{use=normal text, parent=normal text}
+  \setbeamercolor{block title}{%
+    use=normal text,
+    fg=normal text.fg,
+    bg=
+  }
+  \setbeamercolor{block body}{
+    bg=
+  }
 }
 \newcommand{\metropolis@block@fill}{
   \setbeamercolor{block title}{%
     use=normal text,
     fg=normal text.fg,
     bg=normal text.bg!80!fg
+  }
+  \setbeamercolor{block body}{
+    use={block title, normal text},
+    bg=block title.bg!50!normal text.bg
   }
 }
 \setbeamercolor{block title alerted}{%
@@ -201,10 +217,6 @@
 }
 \setbeamercolor{block body alerted}{use=block body, parent=block body}
 \setbeamercolor{block body example}{use=block body, parent=block body}
-\setbeamercolor{block body}{
-  use={block title, normal text},
-  bg=block title.bg!50!normal text.bg
-}
 %    \end{macrocode}
 %
 % Footnotes

--- a/source/beamercolorthememetropolis.dtx
+++ b/source/beamercolorthememetropolis.dtx
@@ -226,7 +226,9 @@
 \setbeamercolor{footnote mark}{fg=.}
 %    \end{macrocode}
 %
-% Process package options
+%
+%
+% \subsubsection{Process package options}
 %
 %    \begin{macrocode}
 \metropolis@color@setdefaults

--- a/source/beamercolorthememetropolis.dtx
+++ b/source/beamercolorthememetropolis.dtx
@@ -13,7 +13,7 @@
 %<driver> \ProvidesFile{beamercolorthememetropolis.dtx}
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthememetropolis}[2016/02/06 Metropolis color theme]
+\ProvidesPackage{beamercolorthememetropolis}[2016/02/21 Metropolis color theme]
 %</package>
 %<driver> \documentclass{ltxdoc}
 %<driver> \usepackage{beamercolorthememetropolis}

--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -13,7 +13,7 @@
 %<driver> \ProvidesFile{beamerfontthememetropolis.dtx}
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthememetropolis}[2016/02/06 Metropolis font theme]
+\ProvidesPackage{beamerfontthememetropolis}[2016/02/21 Metropolis font theme]
 %</package>
 %<driver> \documentclass{ltxdoc}
 %<driver> \usepackage{beamerfontthememetropolis}

--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -13,7 +13,7 @@
 %<driver> \ProvidesFile{beamerinnerthememetropolis.dtx}
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthememetropolis}[2016/02/06 Metropolis inner theme]
+\ProvidesPackage{beamerinnerthememetropolis}[2016/02/21 Metropolis inner theme]
 %</package>
 %<driver> \documentclass{ltxdoc}
 %<driver> \usepackage{beamerinnerthememetropolis}

--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -55,18 +55,6 @@
 %
 % \subsubsection{Options}
 %
-% \begin{macro}{block}
-% This option controls the block style.
-%    \begin{macrocode}
-\pgfkeys{
-  /metropolis/inner/block/.cd,
-    .is choice,
-    transparent/.code=\setlength{\metropolis@blockskip}{0ex},
-    fill/.code=\setlength{\metropolis@blockskip}{1ex},
-}
-%    \end{macrocode}
-% \end{macro}
-%
 % \begin{macro}{sectionpage}
 % The |sectionpage| option defines the behaviour of the sectionpage.
 %    \begin{macrocode}
@@ -86,7 +74,6 @@
 \newcommand{\metropolis@inner@setdefaults}{
   \pgfkeys{/metropolis/inner/.cd,
     sectionpage=progressbar,
-    block=transparent,
   }
 }
 %    \end{macrocode}
@@ -328,87 +315,70 @@
 %
 % \subsubsection{Block environments}
 %
-% Regular block environment
+%
+% \begin{macro}{block}
+% \begin{macro}{block alerted}
+% \begin{macro}{block example}
+%
+%    The three different block environments differ only in their colours.
+%    Rather than repeat the essentially the same template three times, we use
+%    the auxiliary macro |\metropolis@block| to define all three templates.
 %
 %    \begin{macrocode}
-\newlength{\metropolis@blockskip}
-\setbeamertemplate{block begin}{%
+\newlength{\metropolis@blocktitleskip}
+\newlength{\metropolis@blockbodyskip}
+\newcommand{\metropolis@block}[1]{
   \setlength{\parskip}{\metropolis@parskip}
+%    \end{macrocode}
+%
+%    If a background color is defined for the block title or body, a little
+%    bit of padding is added to the corresponding box.
+%
+%    \begin{macrocode}
+  \ifbeamercolorempty[bg]{block title}
+    {\setlength{\metropolis@blocktitleskip}{0ex}}
+    {\setlength{\metropolis@blocktitleskip}{1ex}}
+  \ifbeamercolorempty[bg]{block body}
+    {\setlength{\metropolis@blockbodyskip}{0ex}}
+    {\setlength{\metropolis@blockbodyskip}{1ex}}
   \vspace*{1ex}
+%    \end{macrocode}
+%
+%    Each block environment consists of two (possibly coloured) beamer boxes:
+%    one for the title and one for the body.
+%
+%    \begin{macrocode}
   \begin{beamercolorbox}[%
     ht=2.4ex,
     dp=1ex,
-    leftskip=\metropolis@blockskip,
-    rightskip=\metropolis@blockskip]{block title}
-      \usebeamerfont*{block title}\insertblocktitle%
+    leftskip=\metropolis@blocktitleskip,
+    rightskip=\metropolis@blocktitleskip]{block title#1}
+      \usebeamerfont*{block title#1}\insertblocktitle%
   \end{beamercolorbox}%
-  \vspace*{-1pt}
-  \usebeamerfont{block body}%
+  \nointerlineskip%
+  \usebeamerfont{block body#1}%
   \begin{beamercolorbox}[%
     dp=1ex,
-    leftskip=\metropolis@blockskip,
-    rightskip=\metropolis@blockskip,
-    vmode]{block body}%
-}
-\setbeamertemplate{block end}{%
-  \end{beamercolorbox}
-  \vspace*{0.2ex}
+    leftskip=\metropolis@blockbodyskip,
+    rightskip=\metropolis@blockbodyskip,
+    vmode]{block body#1}%
 }
 %    \end{macrocode}
 %
-% Alerted block environment
+%    This concludes the auxiliary macro |\metropolis@block|. Next,
+%    we define the block beamer templates using this macro.
 %
 %    \begin{macrocode}
-\setbeamertemplate{block alerted begin}{%
-  \setlength{\parskip}{\metropolis@parskip}
-  \vspace*{1ex}
-  \begin{beamercolorbox}[%
-    ht=2.4ex,
-    dp=1ex,
-    leftskip=\metropolis@blockskip,
-    rightskip=\metropolis@blockskip]{block title alerted}
-      \usebeamerfont*{block title alerted}\insertblocktitle%
-  \end{beamercolorbox}%
-  \vspace*{-1pt}
-  \usebeamerfont{block body alerted}%
-  \begin{beamercolorbox}[%
-    dp=1ex,
-    leftskip=\metropolis@blockskip,
-    rightskip=\metropolis@blockskip,
-    vmode]{block body alerted}%
-}
-\setbeamertemplate{block alerted end}{%
-  \end{beamercolorbox}
-  \vspace*{0.2ex}
-}
+\setbeamertemplate{block begin}{\metropolis@block{}}
+\setbeamertemplate{block alerted begin}{\metropolis@block{ alerted}}
+\setbeamertemplate{block example begin}{\metropolis@block{ example}}
+\setbeamertemplate{block end}{\end{beamercolorbox}\vspace*{0.2ex}}
+\setbeamertemplate{block alerted end}{\end{beamercolorbox}\vspace*{0.2ex}}
+\setbeamertemplate{block example end}{\end{beamercolorbox}\vspace*{0.2ex}}
 %    \end{macrocode}
-%
-% Example block environment
-%
-%    \begin{macrocode}
-\setbeamertemplate{block example begin}{%
-  \setlength{\parskip}{\metropolis@parskip}
-  \vspace*{1ex}
-  \begin{beamercolorbox}[%
-    ht=2.4ex,
-    dp=1ex,
-    leftskip=\metropolis@blockskip,
-    rightskip=\metropolis@blockskip]{block title example}
-      \usebeamerfont*{block title example}\insertblocktitle%
-  \end{beamercolorbox}%
-  \vspace*{-1pt}
-  \usebeamerfont{block body example}%
-  \begin{beamercolorbox}[%
-    dp=1ex,
-    leftskip=\metropolis@blockskip,
-    rightskip=\metropolis@blockskip,
-    vmode]{block body example}%
-}
-\setbeamertemplate{block example end}{%
-  \end{beamercolorbox}
-  \vspace*{0.2ex}
-}
-%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+% \end{macro}
 %
 %
 %

--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -429,7 +429,9 @@
 }
 %    \end{macrocode}
 %
-% Process package options
+%
+%
+% \subsubsection{Process package options}
 %
 %    \begin{macrocode}
 \metropolis@inner@setdefaults

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -13,7 +13,7 @@
 %<driver> \ProvidesFile{beamerouterthememetropolis.dtx}
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthememetropolis}[2016/02/06 Metropolis outer theme]
+\ProvidesPackage{beamerouterthememetropolis}[2016/02/21 Metropolis outer theme]
 %</package>
 %<driver> \documentclass{ltxdoc}
 %<driver> \usepackage{beamerouterthememetropolis}

--- a/source/beamerthememetropolis.dtx
+++ b/source/beamerthememetropolis.dtx
@@ -177,9 +177,16 @@
 \def\metropolis@plaintitleformat#1{#1}
 \newcommand{\plain}[2][]{%
   \begingroup
-    \setbeamercolor{background canvas}{
-      use=palette primary,
-      parent=palette primary
+    \ifbeamercolorempty[bg]{palette primary}{
+      \setbeamercolor{background canvas}{
+        use=palette primary,
+        bg=-palette primary.fg
+      }
+    }{
+      \setbeamercolor{background canvas}{
+        use=palette primary,
+        bg=palette primary.bg
+      }
     }
     \begin{frame}[c]{#1}
       \begin{center}

--- a/source/beamerthememetropolis.dtx
+++ b/source/beamerthememetropolis.dtx
@@ -55,17 +55,7 @@
     /metropolis/outer,
     /metropolis/color,
     /metropolis/font,
-  },
-%    \end{macrocode}
-%
-% Currently, the |block| option affects two subthemes and has to be handled
-% separately.
-%
-%    \begin{macrocode}
-  block/.code=\pgfkeysalso{
-    inner/block=#1,
-    color/block=#1,
-  },
+  }
 }
 %    \end{macrocode}
 %

--- a/source/beamerthememetropolis.dtx
+++ b/source/beamerthememetropolis.dtx
@@ -13,7 +13,7 @@
 %<driver> \ProvidesFile{beamerthememetropolis.dtx}
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthememetropolis}[2016/02/06 Metropolis Beamer theme]
+\ProvidesPackage{beamerthememetropolis}[2016/02/21 Metropolis Beamer theme]
 %</package>
 %<driver> \documentclass{ltxdoc}
 %<driver> \usepackage{beamerthememetropolis}


### PR DESCRIPTION
Some users may want to override those defined by Metropolis, either by including a stock colour theme or by defining their own colours. However, if their preferred theme sets a background colour for block environments, they will by default not have enough padding:

```latex
\useoutertheme{metropolis}
\useinnertheme{metropolis}
\usefonttheme{metropolis}
\usecolortheme{orchid}
```

Currently, Metropolis uses an option on the inner theme to control the padding on block elements, so the user could manually set `inner/block=transparent` or `inner/block=fill` based on their colour theme. However, this solution is not very intuitive or discoverable.

This pull request solves this inconvenience and fixes a couple other problems involving the use of other color themes:

- Changes the inner theme's definition of block environments so that the `inner/block` option does not need to be set manually. (We use  `\ifbeamercolorempty` to test whether a background colour has been set for `block title` and `block body` and adjust the padding accordingly.)
- Removes the no-longer-used option `inner/block`, simplifying the internal options-handling code. This will not affect any presentations which use, e.g., `\usetheme[block=fill]{metropolis}`, as the option is still passed to the color theme.
- Fixes the known issue with `\plain` slides under the color theme `fly` — the solution handles the case where `palette primary.bg` is undefined.
- Adds documentation describing potential issues when using other color themes with Metropolis.


