### PR TITLE
Support backup slides

### DIFF
--- a/demo/demo.tex
+++ b/demo/demo.tex
@@ -1,6 +1,7 @@
 \documentclass[10pt]{beamer}
 
 \usetheme{metropolis}
+\usepackage{appendixnumberbeamer}
 
 \usepackage{booktabs}
 \usepackage[scale=2]{ccicons}
@@ -301,6 +302,19 @@ or show \textbf{bold} results.\end{verbatim}
 \end{frame}
 
 \plain{Questions?}
+
+\appendix
+
+\begin{frame}[fragile]{Backup slides}
+  Sometimes, it is useful to add slides at the end of your presentation to
+  refer to during audience questions.
+
+  The best way to do this is to include the \verb|appendixnumberbeamer|
+  package in your preamble and call \verb|\appendix| before your backup slides.
+
+  \themename will automatically turn off slide numbering and progress bars for
+  slides in the appendix.
+\end{frame}
 
 \begin{frame}[allowframebreaks]{References}
 

--- a/doc/metropolistheme.dtx
+++ b/doc/metropolistheme.dtx
@@ -497,6 +497,18 @@ The sub-package |pgfplotsthemetol| defines palettes for |pgfplots| charts
 based on Tol's work.
 
 
+\section{Tips \& Tricks}
+
+\subsection{Backup Slides}
+
+Speakers will often include extra slides at the end of their presentation to
+refer to during audience questions. One easy way to do this is to include the
+\verb|appendixnumberbeamer| package in your preamble and call \verb|\appendix| before your backup slides.
+
+\themename will automatically turn off slide numbering and progress bars for
+slides in the appendix.
+
+
 \section{Known Issues}
 
 \subsection{Title formats}

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -187,6 +187,10 @@
 %
 %
 % \begin{macro}{appendix}
+%    Removes page numbering and per-slide progress bars when |\appendix| is
+%    called. This makes it easier to include additional ``backup slides'' at
+%    the end of the presentation, especially in conjunction with the package
+%    |appendixnumberbeamer|.
 %    \begin{macrocode}
 \AtBeginDocument{%
   \apptocmd{\appendix}{%

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -186,6 +186,18 @@
 %
 %
 %
+% \begin{macro}{appendix}
+%    \begin{macrocode}
+\AtBeginDocument{%
+  \apptocmd{\appendix}{%
+    \pgfkeys{%
+      /metropolis/outer/.cd,
+      numbering=none,
+      progressbar=none}
+    }{}{}
+}
+%    \end{macrocode}
+% \end{macro}
 % \subsubsection{Process package options}
 %
 %    \begin{macrocode}

--- a/source/beamerthememetropolis.dtx
+++ b/source/beamerthememetropolis.dtx
@@ -188,7 +188,7 @@
         bg=palette primary.bg
       }
     }
-    \begin{frame}[c]{#1}
+    \begin{frame}[c,noframenumbering]{#1}
       \begin{center}
         \usebeamercolor[fg]{palette primary}
         \usebeamerfont{plain title}


### PR DESCRIPTION
Following the discussion on #126, I've added a slide in the demo and a note in the documentation describing how the `appendixnumberbeamer` package can be used to create "backup slides" that do not contribute to the total page number of the main presentation.

This pull request also automatically turns off per-slide progress bars and page numbering for backup slides included in this way.