### PR TITLE
Fix multi-line block titles

### DIFF
--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -325,43 +325,58 @@
 %    the auxiliary macro |\metropolis@block| to define all three templates.
 %
 %    \begin{macrocode}
-\newlength{\metropolis@blocktitleskip}
-\newlength{\metropolis@blockbodyskip}
+\newlength{\metropolis@blocktitleadjustleft}
+\newlength{\metropolis@blocktitleadjustright}
+\newlength{\metropolis@blockbodyadjust}
 \newcommand{\metropolis@block}[1]{
-  \setlength{\parskip}{\metropolis@parskip}
+  \par\vskip\medskipamount
 %    \end{macrocode}
 %
-%    If a background color is defined for the block title or body, a little
-%    bit of padding is added to the corresponding box.
+%    If a background color is defined for the block title or body, we need to
+%    add a little bit of padding to the corresponding box. Ideally, this would
+%    be accomplished by setting |colsep=1ex|, which is intended to add
+%    ``color separation space'' only when the box has a colored background.
+%    Unfortunately, |colsep| also adds this separation if the background color
+%    is inherited, even if the inherited color is actually empty.
+%    (The technical reason for this boils down to the fact that the |\ifx|
+%    directive does not expand macros.)
+%
+%    To achieve the correct spacing for |alertblock|s and |exampleblock|s
+%    as well as for normal blocks, we have to set |sep=1ex| in all cases and
+%    then subtract it from the left and right edges if |block title| has
+%    an empty background. This solution assumes that either all or none of
+%    |block title|, |block title alerted|, and |block title example| have an
+%    empty background, and likewise for |block body|, |block body alerted|,
+%    and |block body example|.
 %
 %    \begin{macrocode}
-  \ifbeamercolorempty[bg]{block title}
-    {\setlength{\metropolis@blocktitleskip}{0ex}}
-    {\setlength{\metropolis@blocktitleskip}{1ex}}
+  \ifbeamercolorempty[bg]{block title}{
+    \setlength{\metropolis@blocktitleadjustleft}{-1ex}
+    \setlength{\metropolis@blocktitleadjustright}{-1ex plus 4em}
+  }{
+    \setlength{\metropolis@blocktitleadjustleft}{0pt}
+    \setlength{\metropolis@blocktitleadjustright}{0pt plus 4em}
+  }
   \ifbeamercolorempty[bg]{block body}
-    {\setlength{\metropolis@blockbodyskip}{0ex}}
-    {\setlength{\metropolis@blockbodyskip}{1ex}}
-  \vspace*{1ex}
-%    \end{macrocode}
-%
-%    Each block environment consists of two (possibly coloured) beamer boxes:
-%    one for the title and one for the body.
-%
-%    \begin{macrocode}
+    {\setlength{\metropolis@blockbodyadjust}{-1ex}}
+    {\setlength{\metropolis@blockbodyadjust}{0ex}}
+  \setlength{\parskip}{0pt}
   \begin{beamercolorbox}[%
-    ht=2.4ex,
-    dp=1ex,
-    leftskip=\metropolis@blocktitleskip,
-    rightskip=\metropolis@blocktitleskip]{block title#1}
-      \usebeamerfont*{block title#1}\insertblocktitle%
+    sep=1ex,
+    leftskip=\metropolis@blocktitleadjustleft,
+    rightskip=\metropolis@blocktitleadjustright]{block title#1}
+      \usebeamerfont*{block title#1}%
+      \insertblocktitle%
   \end{beamercolorbox}%
   \nointerlineskip%
   \usebeamerfont{block body#1}%
   \begin{beamercolorbox}[%
-    dp=1ex,
-    leftskip=\metropolis@blockbodyskip,
-    rightskip=\metropolis@blockbodyskip,
+    sep=1ex,
+    leftskip=\metropolis@blockbodyadjust,
+    rightskip=\metropolis@blockbodyadjust,
     vmode]{block body#1}%
+    \vspace{-\metropolis@parskip}
+    \setlength{\parskip}{\metropolis@parskip}
 }
 %    \end{macrocode}
 %

--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -325,13 +325,16 @@
 %    the auxiliary macro |\metropolis@block| to define all three templates.
 %
 %    \begin{macrocode}
-\newlength{\metropolis@blocktitlesep}
-\newlength{\metropolis@blockbodysep}
+\newlength{\metropolis@blocksep}
+\newlength{\metropolis@blockadjust}
+\setlength{\metropolis@blocksep}{0.75ex}
+\setlength{\metropolis@blockadjust}{0.25ex}
 \providecommand{\metropolis@strut}{%
   \vphantom{ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz()}%
 }
 \newcommand{\metropolis@block}[1]{
-  \par\vskip\medskipamount
+  \par\vskip\medskipamount%
+  \setlength{\parskip}{0pt}
 %    \end{macrocode}
 %
 %    If a background color is defined for the block title or body, we need to
@@ -344,40 +347,66 @@
 %    directive does not expand macros.)
 %
 %    To achieve the correct spacing for |alertblock|s and |exampleblock|s
-%    as well as for normal blocks, we have to explicitly set the amount of
-%    padding in a conditional based on whether the |block title| and
-%    |block body| have an empty background.
-%    This solution assumes that either all or none of |block title|,
+%    as well as for normal blocks, we have to begin the |beamercolorbox|
+%    differently based on whether |block title| has an empty background.
+%    (We assume that either all or none of |block title|,
 %    |block title alerted|, and |block title example| have an empty
-%    background, and likewise for |block body|, |block body alerted|,
-%    and |block body example|.
+%    background).
+%
+%    If the |block title| background is empty, we just need to set a rightskip
+%    for a nice ragged-right block title.
 %
 %    \begin{macrocode}
-  \ifbeamercolorempty[bg]{block title}
-    {\setlength{\metropolis@blocktitlesep}{0pt}}
-    {\setlength{\metropolis@blocktitlesep}{0.5ex}}
-  \ifbeamercolorempty[bg]{block body}
-    {\setlength{\metropolis@blockbodysep}{0pt}}
-    {\setlength{\metropolis@blockbodysep}{0.75ex}}
-  \setlength{\parskip}{0pt}
-  \begin{beamercolorbox}[%
-    sep=\metropolis@blocktitlesep,
-    leftskip=0.5\metropolis@blocktitlesep,
-    rightskip=0.5\metropolis@blocktitlesep plus 4em]{block title#1}%
+  \ifbeamercolorempty[bg]{block title}{%
+    \begin{beamercolorbox}[rightskip=0pt plus 4em]{block title#1}%
+  }%
+%   \end{macrocode}
+%
+%   Otherwise, if the |block title| has a background, we set the padding based
+%   on |\metropolis@blockskip|. However, we have to visually compensate for
+%   the |\metropolis@strut| added to the block title (see below) by
+%   subtracting |\metropolis@blockadjust| from the top and bottom padding.
+%
+%   \begin{macrocode}
+  {%
+    \begin{beamercolorbox}[
+      sep=\dimexpr\metropolis@blocksep-\metropolis@blockadjust\relax,
+      leftskip=\metropolis@blockadjust,
+      rightskip=\dimexpr\metropolis@blockadjust plus 4em\relax
+    ]{block title#1}%
+  }%
+%   \end{macrocode}
+%
+%   We can now set the contents of the |block title|. The zero-width but
+%   positive-height box |\metropolis@strut| ensures that the block title box
+%   has a consistent height, even if it lacks punctuation, ascenders, or
+%   descenders.
+%
+%   \begin{macrocode}
       \usebeamerfont*{block title#1}%
       \metropolis@strut%
       \insertblocktitle%
       \metropolis@strut%
   \end{beamercolorbox}%
+%   \end{macrocode}
+%
+%   Next, we typeset the |block body|. This the code is similar to, but simpler
+%   than, the |block title| code since we don't need to adjust for any struts.
+%
+%   \begin{macrocode}
   \nointerlineskip%
-  \usebeamerfont{block body#1}%
-  \begin{beamercolorbox}[sep=\metropolis@blockbodysep, vmode]{block body#1}%
-    \ifbeamercolorempty[bg]{block body}{}{\vspace{-\metropolis@parskip}}
-    \setlength{\parskip}{\metropolis@parskip}
+  \ifbeamercolorempty[bg]{block body}{
+    \begin{beamercolorbox}[vmode]{block body#1}%
+  }{%
+    \begin{beamercolorbox}[sep=\metropolis@blocksep, vmode]{block body#1}%
+    \vspace{-\metropolis@parskip}
+  }%
+      \usebeamerfont{block body#1}%
+      \setlength{\parskip}{\metropolis@parskip}%
 }
 %    \end{macrocode}
 %
-%    This concludes the auxiliary macro |\metropolis@block|. Next,
+%    This concludes the auxiliary macro |\metropolis@block|. Finally,
 %    we define the block beamer templates using this macro.
 %
 %    \begin{macrocode}

--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -327,7 +327,6 @@
 %    \begin{macrocode}
 \newlength{\metropolis@blocktitlesep}
 \newlength{\metropolis@blockbodysep}
-\newcommand{\foo}{20}
 \providecommand{\metropolis@strut}{%
   \vphantom{ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz()}%
 }

--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -325,9 +325,9 @@
 %    the auxiliary macro |\metropolis@block| to define all three templates.
 %
 %    \begin{macrocode}
-\newlength{\metropolis@blocktitleadjustleft}
-\newlength{\metropolis@blocktitleadjustright}
-\newlength{\metropolis@blockbodyadjust}
+\newlength{\metropolis@blocktitlesep}
+\newlength{\metropolis@blockbodysep}
+\newcommand{\foo}{20}
 \providecommand{\metropolis@strut}{%
   \vphantom{ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz()}%
 }
@@ -337,7 +337,7 @@
 %
 %    If a background color is defined for the block title or body, we need to
 %    add a little bit of padding to the corresponding box. Ideally, this would
-%    be accomplished by setting |colsep=1ex|, which is intended to add
+%    be accomplished by setting |colsep=0.75ex|, which is intended to add
 %    ``color separation space'' only when the box has a colored background.
 %    Unfortunately, |colsep| also adds this separation if the background color
 %    is inherited, even if the inherited color is actually empty.
@@ -345,29 +345,26 @@
 %    directive does not expand macros.)
 %
 %    To achieve the correct spacing for |alertblock|s and |exampleblock|s
-%    as well as for normal blocks, we have to set |sep=1ex| in all cases and
-%    then subtract it from the left and right edges if |block title| has
-%    an empty background. This solution assumes that either all or none of
-%    |block title|, |block title alerted|, and |block title example| have an
-%    empty background, and likewise for |block body|, |block body alerted|,
+%    as well as for normal blocks, we have to explicitly set the amount of
+%    padding in a conditional based on whether the |block title| and
+%    |block body| have an empty background.
+%    This solution assumes that either all or none of |block title|,
+%    |block title alerted|, and |block title example| have an empty
+%    background, and likewise for |block body|, |block body alerted|,
 %    and |block body example|.
 %
 %    \begin{macrocode}
-  \ifbeamercolorempty[bg]{block title}{
-    \setlength{\metropolis@blocktitleadjustleft}{-1ex}
-    \setlength{\metropolis@blocktitleadjustright}{-1ex plus 4em}
-  }{
-    \setlength{\metropolis@blocktitleadjustleft}{0pt}
-    \setlength{\metropolis@blocktitleadjustright}{0pt plus 4em}
-  }
+  \ifbeamercolorempty[bg]{block title}
+    {\setlength{\metropolis@blocktitlesep}{0pt}}
+    {\setlength{\metropolis@blocktitlesep}{0.5ex}}
   \ifbeamercolorempty[bg]{block body}
-    {\setlength{\metropolis@blockbodyadjust}{-1ex}}
-    {\setlength{\metropolis@blockbodyadjust}{0ex}}
+    {\setlength{\metropolis@blockbodysep}{0pt}}
+    {\setlength{\metropolis@blockbodysep}{0.75ex}}
   \setlength{\parskip}{0pt}
   \begin{beamercolorbox}[%
-    sep=1ex,
-    leftskip=\metropolis@blocktitleadjustleft,
-    rightskip=\metropolis@blocktitleadjustright]{block title#1}
+    sep=\metropolis@blocktitlesep,
+    leftskip=0.5\metropolis@blocktitlesep,
+    rightskip=0.5\metropolis@blocktitlesep plus 4em]{block title#1}%
       \usebeamerfont*{block title#1}%
       \metropolis@strut%
       \insertblocktitle%
@@ -375,12 +372,8 @@
   \end{beamercolorbox}%
   \nointerlineskip%
   \usebeamerfont{block body#1}%
-  \begin{beamercolorbox}[%
-    sep=1ex,
-    leftskip=\metropolis@blockbodyadjust,
-    rightskip=\metropolis@blockbodyadjust,
-    vmode]{block body#1}%
-    \vspace{-\metropolis@parskip}
+  \begin{beamercolorbox}[sep=\metropolis@blockbodysep, vmode]{block body#1}%
+    \ifbeamercolorempty[bg]{block body}{}{\vspace{-\metropolis@parskip}}
     \setlength{\parskip}{\metropolis@parskip}
 }
 %    \end{macrocode}

--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -328,6 +328,9 @@
 \newlength{\metropolis@blocktitleadjustleft}
 \newlength{\metropolis@blocktitleadjustright}
 \newlength{\metropolis@blockbodyadjust}
+\providecommand{\metropolis@strut}{%
+  \vphantom{ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz()}%
+}
 \newcommand{\metropolis@block}[1]{
   \par\vskip\medskipamount
 %    \end{macrocode}
@@ -366,7 +369,9 @@
     leftskip=\metropolis@blocktitleadjustleft,
     rightskip=\metropolis@blocktitleadjustright]{block title#1}
       \usebeamerfont*{block title#1}%
+      \metropolis@strut%
       \insertblocktitle%
+      \metropolis@strut%
   \end{beamercolorbox}%
   \nointerlineskip%
   \usebeamerfont{block body#1}%

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -148,7 +148,7 @@
 %    Templates for the frame title, which is optionally underlined with a
 %    progress bar.
 %    \begin{macrocode}
-\providecommand{\metropolis@strut}{%
+\newcommand{\metropolis@frametitlestrut}{
   \vphantom{ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz()}%
 }
 \defbeamertemplate{frametitle}{plain}{%
@@ -157,9 +157,7 @@
       wd=\paperwidth,%
       sep=1.5ex,%
     ]{frametitle}%
-  \metropolis@strut%
-  \insertframetitle%
-  \metropolis@strut%
+  \metropolis@frametitlestrut\insertframetitle\metropolis@frametitlestrut%
   \end{beamercolorbox}%
 }
 %    \end{macrocode}

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -148,7 +148,7 @@
 %    Templates for the frame title, which is optionally underlined with a
 %    progress bar.
 %    \begin{macrocode}
-\newcommand{\metropolis@frametitlestrut}{
+\providecommand{\metropolis@strut}{%
   \vphantom{ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz()}%
 }
 \defbeamertemplate{frametitle}{plain}{%
@@ -157,7 +157,9 @@
       wd=\paperwidth,%
       sep=1.5ex,%
     ]{frametitle}%
-  \metropolis@frametitlestrut\insertframetitle\metropolis@frametitlestrut%
+  \metropolis@strut%
+  \insertframetitle%
+  \metropolis@strut%
   \end{beamercolorbox}%
 }
 %    \end{macrocode}


### PR DESCRIPTION
For quite a while, ᴍᴇᴛʀᴏᴘᴏʟɪs has had trouble with block environments with long titles:

![screen shot 2016-02-24 at 10 05 00 am](https://cloud.githubusercontent.com/assets/1131743/13295584/6d92ff3c-dade-11e5-89c6-a6b806650f2b.png)

This pull request solves this issue while maintaining the current behaviour for single-line blocks:
![screen shot 2016-02-24 at 10 05 55 am](https://cloud.githubusercontent.com/assets/1131743/13296399/3d5e0556-dae2-11e5-8feb-7a7d0a6de87a.png)
![screen shot 2016-02-24 at 10 06 45 am](https://cloud.githubusercontent.com/assets/1131743/13296528/d2902636-dae2-11e5-89b2-e51ffa74dc75.png)

Technical details:
- Previously, we fixed the height and depth of the `beamercolorbox` in block titles, and added padding to the right and left when `block title.bg` was nonempty. Now, we set `sep` for the `beamercolorbox` and add negative padding to the right and left when `block title.bg` is empty. This is similar to how we fixed multi-line frame titles a while back.
- Just replacing `dp` and `ht` with `sep` wouldn't be enough, though. The padding at the top of a beamer box seems to actually be `sep + parskip`; since ᴍᴇᴛʀᴏᴘᴏʟɪs increases the `\parskip` length, we'd have too much padding at the top if we didn't do something more. The solution is to reset `\parskip` to zero at the beginning of `block begin` and restore the ᴍᴇᴛʀᴏᴘᴏʟɪs `\parskip` length when the block body begins.
- This pull request also adds some wiggle room to the `rightskip` for the block title to produce a good ragged right edge.
- Finally, I added some comments explaining why we can't just use `colsep`, which would be the ideal solution if it actually worked.