### PR TITLE
new frame title struts – fixes #165

### DIFF
--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -159,11 +159,7 @@
 \newcommand{\metropolis@frametitlestrut@start}{
   \rule{0pt}{\metropolis@frametitle@padding +%
     \totalheightof{%
-      \ifcsname metropolis@frametitleformat\endcsname%
-        \metropolis@frametitleformat X%
-      \else%
-        X%
-      \fi%
+      \ifcsdef{metropolis@frametitleformat}{\metropolis@frametitleformat X}{X}%
     }%
   }%
 }

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -154,16 +154,31 @@
 %    Templates for the frame title, which is optionally underlined with a
 %    progress bar.
 %    \begin{macrocode}
-\newcommand{\metropolis@frametitlestrut}{
-  \vphantom{ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz()}%
+\newlength{\metropolis@frametitle@padding}
+\setlength{\metropolis@frametitle@padding}{1.5ex}
+\newcommand{\metropolis@frametitlestrut@start}{
+  \rule{0pt}{\metropolis@frametitle@padding +%
+    \totalheightof{%
+      \ifcsname metropolis@frametitleformat\endcsname%
+        \metropolis@frametitleformat X%
+      \else%
+        X%
+      \fi%
+    }%
+  }%
+}
+\newcommand{\metropolis@frametitlestrut@end}{
+  \rule[-\metropolis@frametitle@padding]{0pt}{\metropolis@frametitle@padding}
 }
 \defbeamertemplate{frametitle}{plain}{%
   \nointerlineskip%
   \begin{beamercolorbox}[%
       wd=\paperwidth,%
-      sep=1.5ex,%
+      sep=0pt,%
+      leftskip=\metropolis@frametitle@padding,%
+      rightskip=\metropolis@frametitle@padding,%
     ]{frametitle}%
-  \metropolis@frametitlestrut\insertframetitle\metropolis@frametitlestrut%
+  \metropolis@frametitlestrut@start\insertframetitle\metropolis@frametitlestrut@end%
   \end{beamercolorbox}%
 }
 %    \end{macrocode}


### PR DESCRIPTION
As my original branch was too outdated I had to reimplement this. As @rchurchley moved all the title format settings to the font theme the struts couldn't be declared alongside the title format settings anymore without keeping the outer theme and the font theme independent from each other.

So I added a check if `metropolis@frametitleformat` is defined. If this is the case we use it in the calculation and otherwise not.

Probably somebody should check it again if everything is working as expected, but I'm confident it does.