### PR TITLE
Automatically get version, date for manual

### DIFF
--- a/doc/metropolistheme.dtx
+++ b/doc/metropolistheme.dtx
@@ -144,10 +144,12 @@
 
 \newcommand{\themename}{\textbf{\textsc{metropolis}}\xspace}
 
-\GetFileInfo{beamerthememetropolis.dtx}
+\usepackage{readprov}
+\ReadPackageInfos{beamerthememetropolis}
+
 \title{Modern Beamer Presentations with the \themename package}
 \author{Matthias Vogelgesang \\ \url{matthias.vogelgesang@gmail.com}}
-\date{v1.1 --- 2016/02/06}
+\date{\fileversion~---~\filedate}
 
 \begin{document}
 

--- a/source/beamerthememetropolis.dtx
+++ b/source/beamerthememetropolis.dtx
@@ -13,7 +13,8 @@
 %<driver> \ProvidesFile{beamerthememetropolis.dtx}
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthememetropolis}[2016/02/21 Metropolis Beamer theme]
+\ProvidesPackage{beamerthememetropolis}
+  [2016/02/21 v1.1 Metropolis Beamer theme]
 %</package>
 %<driver> \documentclass{ltxdoc}
 %<driver> \usepackage{beamerthememetropolis}


### PR DESCRIPTION
As discussed in #81 and #87, we would like to have the manual automatically update the version number and date in `\maketitle` according to the `\ProvidesPackage` declaration of `beamerthememetropolis.sty`. Normally, we'd do this with `\fileversion` and `\filedate` after calling `\GetFileInfo{beamerthememetropolis}`, but unfortunately `\GetFileInfo{file}` does not work [unless `file` is loaded during the LaTeX run](http://tug.ctan.org/info/latexfileinfo-pkgs/latexfileinfo_pkgs.htm). This is not an option for us since `beamerthememetropolis` depends on the `beamer` class.

As it turns out, there is a package to solve this exact problem: `readprov` provides a command to read a file's metadata without actually loading it. This pull request adopts this solution.