### PR TITLE
Explicitly set italic, bold, and bolditalic fonts

### DIFF
--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -95,16 +95,24 @@
 %
 %    \begin{macrocode}
   \iffontsavailable{Fira Sans Light,%
-                Fira Sans Light Italic,%
-                Fira Sans,%
-                Fira Sans Italic}{%
-    \setsansfont[BoldFont={Fira Sans}]{Fira Sans Light}%
+                    Fira Sans Light Italic,%
+                    Fira Sans,%
+                    Fira Sans Italic}%
+  {%
+    \setsansfont[ItalicFont={Fira Sans Light Italic},%
+                 BoldFont={Fira Sans},%
+                 BoldItalicFont={Fira Sans Italic}]%
+                {Fira Sans Light}%
   }{%
     \iffontsavailable{Fira Sans Light OT,%
-                  Fira Sans Light Italic OT,%
-                  Fira Sans OT,%
-                  Fira Sans Italic OT}{%
-      \setsansfont[BoldFont={Fira Sans OT}]{Fira Sans Light OT}%
+                      Fira Sans Light Italic OT,%
+                      Fira Sans OT,%
+                      Fira Sans Italic OT}%
+    {%
+      \setsansfont[ItalicFont={Fira Sans Light Italic OT},%
+                   BoldFont={Fira Sans OT},%
+                   BoldItalicFont={Fira Sans Italic OT}]%
+                  {Fira Sans Light OT}%
     }{%
       \PackageWarning{beamerthememetropolis}{%
         Could not find Fira Sans fonts%
@@ -112,10 +120,10 @@
     }
   }
   \iffontsavailable{Fira Mono, Fira Mono Bold}{%
-    \setmonofont{Fira Mono}%
+    \setmonofont[BoldFont={Fira Mono Medium}]{Fira Mono}%
   }{%
     \iffontsavailable{Fira Mono OT, Fira Mono Bold OT}{%
-      \setmonofont{Fira Mono OT}%
+      \setmonofont[BoldFont={Fira Mono Medium OT}]{Fira Mono OT}%
     }{%
       \PackageWarning{beamerthememetropolis}{%
         Could not find Fira Mono fonts%


### PR DESCRIPTION
Fixes the problem reported in #187: it seems that LuaLaTeX cannot automatically find the italic version of a font which is itself a weight-variant of another font. In particular, we have to explicitly tell it to find the italic version of Fira Sans Light in the font theme.