### PR TITLE
Use frame key for standout slides, move to inner theme

### DIFF
--- a/demo/demo.tex
+++ b/demo/demo.tex
@@ -301,7 +301,9 @@ or show \textbf{bold} results.\end{verbatim}
 
 \end{frame}
 
-\plain{Questions?}
+\begin{frame}[standout]
+  Questions?
+\end{frame}
 
 \appendix
 

--- a/doc/metropolistheme.dtx
+++ b/doc/metropolistheme.dtx
@@ -451,11 +451,18 @@ regular lined figures for math, you could add the following to your preamble:
 
 \subsection{Commands}
 
-\begin{macro}{\plain}
-The \lstinline|\plain{title=[]}{<body>}| command sets a slide in with a plain
-dark background, which can be useful to focus attention on a single sentence
-or image.
-\end{macro}
+\subsubsection{Standout frames}
+
+The \themename inner theme offers a custom frame format with large, centered
+text and an inverted background --- perfect for focusing attention on
+single sentence or image. To use it, add the key |standout| to the frame:
+
+\begin{lstlisting}
+\begin{frame}[standout]
+    Thank you!
+\end{frame}
+\end{lstlisting}
+
 
 
 \section{\texttt{pgfplots} integration}
@@ -549,8 +556,7 @@ only alphabetic characters and do not require the expansion of any macros.
 \themename can be used along with any other Beamer color theme, such as
 |crane| or |seahorse|. If you wish to do this, it is usually best to include
 the \themename subpackages individually so the \themename color theme is
-never loaded. Although this will disable some features, including
-|\plain| slides, it will prevent conflicts between the \themename color theme
+never loaded. This will prevent conflicts between the \themename color theme
 and your preferred theme.
 
 For example, overriding the color theme as follows may not work as expected because |\usetheme{metropolis}| loads the \themename color theme, which

--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -147,8 +147,6 @@
 \setbeamerfont{date}{size=\small}
 \setbeamerfont{section title}{size=\Large,%
                               series=\bfseries}
-\setbeamerfont{plain title}{size=\Large,%
-                            series=\bfseries}
 \setbeamerfont{block title}{size=\normalsize,%
                             series=\bfseries}
 \setbeamerfont{block title alerted}{size=\normalsize,%
@@ -168,6 +166,8 @@
                                             series=\normalfont}
 \setbeamerfont{bibliography entry note}{size=\small,%
                                         series=\normalfont}
+\setbeamerfont{standout}{size=\Large,%
+                         series=\bfseries}
 %    \end{macrocode}
 %
 %

--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -46,6 +46,7 @@
 %
 %    \begin{macrocode}
 \RequirePackage{etoolbox}
+\RequirePackage{keyval}
 \RequirePackage{calc}
 \RequirePackage{pgfopts}
 \RequirePackage{tikz}
@@ -430,6 +431,60 @@
 %    \end{macrocode}
 %
 %
+%
+% \subsubsection{Standout frames}
+%
+% \themename offers a custom frame format with large, centered text and an
+% inverted background. To use it, add the key |standout| to the frame:
+% |\begin{frame}[standout] ... \end{frame}|.
+%
+% \begin{macro}{standout}
+%
+%     Optional arguments to Beamer's frames are implemented using
+%     |\define@key| from the |keyval| package, which will execute code when the
+%     defined option is called. For the |standout| option, we begin a group,
+%     change the colors and fonts, and set a \centering alignment.
+%
+%    \begin{macrocode}
+\providebool{metropolis@standout}
+\define@key{beamerframe}{standout}[true]{%
+  \booltrue{metropolis@standout}
+  \begingroup
+    \setkeys{beamerframe}{c}
+    \setkeys{beamerframe}{noframenumbering}
+    \ifbeamercolorempty[bg]{palette primary}{
+      \setbeamercolor{background canvas}{
+        use=palette primary,
+        bg=-palette primary.fg
+      }
+    }{
+      \setbeamercolor{background canvas}{
+        use=palette primary,
+        bg=palette primary.bg
+      }
+    }
+  \centering
+  \usebeamercolor[fg]{palette primary}
+  \usebeamerfont{standout}
+}
+%    \end{macrocode}
+%
+%    Then we just have to close the group after the standout slide is finished
+%    in order to restore the colours and fonts for the rest of the
+%    presentation. Unfortunately, we cannot use \AfterEndEnvironment{frame} for
+%    this (see \url{http://tex.stackexchange.com/questions/226319/}).
+%    Instead, we add the |\endgroup| to |\beamer@reseteecodes|, which is run
+%    exactly once at the end of each slide.
+%
+%    \begin{macrocode}
+  \apptocmd{\beamer@reseteecodes}{%
+    \ifbool{metropolis@standout}{
+      \endgroup
+      \boolfalse{metropolis@standout}
+    }{}
+  }{}{}
+%    \end{macrocode}
+% \end{macro}
 %
 % \subsubsection{Process package options}
 %

--- a/source/beamerthememetropolis.dtx
+++ b/source/beamerthememetropolis.dtx
@@ -67,22 +67,22 @@
     .is choice,
     regular/.code={%
       \let\metropolis@plaintitleformat\@empty%
-      \setbeamerfont{plain title}{shape=\normalfont}%
+      \setbeamerfont{standout}{shape=\normalfont}%
     },
     smallcaps/.code={%
       \let\metropolis@plaintitleformat\@empty%
-      \setbeamerfont{plain title}{shape=\scshape}%
+      \setbeamerfont{standout}{shape=\scshape}%
     },
     allsmallcaps/.code={%
       \let\metropolis@plaintitleformat\MakeLowercase%
-      \setbeamerfont{plain title}{shape=\scshape}%
+      \setbeamerfont{standout}{shape=\scshape}%
       \PackageWarning{beamerthememetropolis}{%
         Be aware that titleformat plain=allsmallcaps can lead to problems%
       }
     },
     allcaps/.code={%
       \let\metropolis@plaintitleformat\MakeUppercase%
-      \setbeamerfont{plain title}{shape=\normalfont}%
+      \setbeamerfont{standout}{shape=\normalfont}%
       \PackageWarning{beamerthememetropolis}{%
         Be aware that titleformat plain=allcaps can lead to problems%
       }
@@ -176,26 +176,13 @@
 %    \begin{macrocode}
 \def\metropolis@plaintitleformat#1{#1}
 \newcommand{\plain}[2][]{%
-  \begingroup
-    \ifbeamercolorempty[bg]{palette primary}{
-      \setbeamercolor{background canvas}{
-        use=palette primary,
-        bg=-palette primary.fg
-      }
-    }{
-      \setbeamercolor{background canvas}{
-        use=palette primary,
-        bg=palette primary.bg
-      }
-    }
-    \begin{frame}[c,noframenumbering]{#1}
-      \begin{center}
-        \usebeamercolor[fg]{palette primary}
-        \usebeamerfont{plain title}
-        \metropolis@plaintitleformat{#2}
-      \end{center}
-    \end{frame}
-  \endgroup
+  \PackageWarning{beamerthememetropolis}{%
+    The syntax `\plain' may be deprecated in a future version of Metropolis.
+    Please use a frame with [standout] instead.
+  }
+  \begin{frame}[standout]{#1}
+    \metropolis@plaintitleformat{#2}
+  \end{frame}
 }
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
As discussed in #11, I have reimplemented the `\plain` command for focused, colour-inverted slides as an optional key for Beamer frames. The new syntax is:

```latex
\begin{frame}[standout]
  Questions?
\end{frame}
```

This change does not affect older presentations which use `\plain{...}`, although as per @matze's suggestion, `\plain` now issues a warning that it "may be deprecated" in a future version and `[standout]` should be preferred.