### PR TITLE
Add support for subsections

### DIFF
--- a/doc/metropolistheme.dtx
+++ b/doc/metropolistheme.dtx
@@ -356,6 +356,12 @@ The list of options is structured as shown in the following example.
   disables the section page.
 }
 
+\DescribeOption{subsectionpage}{none, simple, progressbar}{none}{
+  Optionally adds a slide at the start of each subsection. If enabled with
+  the |simple| or |progressbar| options, the style of the |section page| will
+  be updated to match the style of the |subsection page|.
+}
+
 
 \subsubsection{Outer theme}
 

--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -56,14 +56,31 @@
 % \subsubsection{Options}
 %
 % \begin{macro}{sectionpage}
-% The |sectionpage| option defines the behaviour of the sectionpage.
+%    Optionally add a slide marking the beginning of each section.
 %    \begin{macrocode}
 \pgfkeys{
   /metropolis/inner/sectionpage/.cd,
     .is choice,
-    none/.code=\metropolis@sectionpage@none,
-    simple/.code=\metropolis@sectionpage@simple,
-    progressbar/.code=\metropolis@sectionpage@progressbar,
+    none/.code=\metropolis@disablesectionpage,
+    simple/.code={\metropolis@enablesectionpage
+                  \setbeamertemplate{section page}[simple]},
+    progressbar/.code={\metropolis@enablesectionpage
+                       \setbeamertemplate{section page}[progressbar]},
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{sectionpage}
+%    Optionally add a slide marking the beginning of each subsection.
+%    \begin{macrocode}
+\pgfkeys{
+  /metropolis/inner/subsectionpage/.cd,
+    .is choice,
+    none/.code=\metropolis@disablesubsectionpage,
+    simple/.code={\metropolis@enablesubsectionpage
+                  \setbeamertemplate{section page}[simple]},
+    progressbar/.code={\metropolis@enablesubsectionpage
+                       \setbeamertemplate{section page}[progressbar]},
 }
 %    \end{macrocode}
 % \end{macro}
@@ -74,6 +91,7 @@
 \newcommand{\metropolis@inner@setdefaults}{
   \pgfkeys{/metropolis/inner/.cd,
     sectionpage=progressbar,
+    subsectionpage=none
   }
 }
 %    \end{macrocode}
@@ -233,26 +251,17 @@
 %   Template for the section title slide at the beginning of each section.
 %
 %    \begin{macrocode}
-\newcommand{\metropolis@sectionpage@none}{
-  \AtBeginSection{
-    % intenionally empty
-  }
-}
 \defbeamertemplate{section page}{simple}{
-  \centering
-  \usebeamercolor[fg]{section title}
-  \usebeamerfont{section title}
-  \insertsectionhead\\
-}
-\newcommand{\metropolis@sectionpage@simple}{
-  \setbeamertemplate{section page}[simple]
-  \AtBeginSection{
-    \ifbeamer@inframe
-      \sectionpage
-    \else
-      \frame[plain,c,noframenumbering]{\sectionpage}
+  \begin{center}
+    \usebeamercolor[fg]{section title}
+    \usebeamerfont{section title}
+    \insertsectionhead\par
+    \ifx\insertsubsection\@empty\else
+      \usebeamercolor[fg]{subsection title}
+      \usebeamerfont{subsection title}
+      \insertsubsection
     \fi
-  }
+  \end{center}
 }
 \defbeamertemplate{section page}{progressbar}{
   \centering
@@ -262,17 +271,53 @@
     \usebeamerfont{section title}
     \insertsectionhead\\[-1ex]
     \usebeamertemplate*{progress bar in section page}
+    \par
+    \ifx\insertsubsection\@empty\else%
+      \usebeamercolor[fg]{subsection title}%
+      \usebeamerfont{subsection title}%
+      \insertsubsection
+    \fi
   \end{minipage}
   \par
   \vspace{\baselineskip}
 }
-\newcommand{\metropolis@sectionpage@progressbar}{
-  \setbeamertemplate{section page}[progressbar]
+\newcommand{\metropolis@disablesectionpage}{
+  \AtBeginSection{
+    % intentionally empty
+  }
+}
+\newcommand{\metropolis@enablesectionpage}{
   \AtBeginSection{
     \ifbeamer@inframe
       \sectionpage
     \else
       \frame[plain,c,noframenumbering]{\sectionpage}
+    \fi
+  }
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{subsection page}
+%
+%   Template for the subsection title slide that can optionally be added to
+%   at the beginning of each subsection.
+%
+%    \begin{macrocode}
+\setbeamertemplate{subsection page}{%
+  \usebeamertemplate*{section page}
+}
+\newcommand{\metropolis@disablesubsectionpage}{
+  \AtBeginSubsection{
+    % intentionally empty
+  }
+}
+\newcommand{\metropolis@enablesubsectionpage}{
+  \AtBeginSubsection{
+    \ifbeamer@inframe
+      \subsectionpage
+    \else
+      \frame[plain,c,noframenumbering]{\subsectionpage}
     \fi
   }
 }


### PR DESCRIPTION
Although I haven't generally used subsections in my beamer presentations, I understand that they can be an essential feature when giving long tutorials or multi-day workshops, for example. @eddelbuettel asked us to implement some form of subsectioning in #53, and this pull request is making good on my promise nearly a year ago to do so. :)

Without duplicating any code, this pull request defines two `subsection page` templates matching the `section page`s, containing both the section and subsection title.

`simple`
![screen shot 2016-03-04 at 9 46 54 pm](https://cloud.githubusercontent.com/assets/1131743/13546116/6e6cd8de-e258-11e5-8a81-93500662efba.png)

`progressbar`
![screen shot 2016-03-04 at 11 31 11 pm](https://cloud.githubusercontent.com/assets/1131743/13546385/3c4e4fa0-e261-11e5-8ec9-75d6522417e7.png)

These templates are not enabled by default; as @matze pointed out in #53,

> there is a tendency to break up a presentation into smaller topics if a theme encourages that (e.g. showing little dots and upcoming titles).... A more organic flow probably helps [the audience stay] awake than a overly hierarchic structure.

To encourage presenters to use subsections only as a tool to orient the audience during a long presentation, we require them to use the new inner theme option `subsectionpage` if they want to turn on subsection slides. 

The possible values of `subsectionpage` are `none`, `simple`, and `progressbar`, matching those of `sectionpage`. In fact, the templates for the section and subsection pages are tied together so they will always match if both are enabled. They can, of course, be enabled and disabled independently.