### PR TITLE
Allow user to define empty (e.g.) alertblock background

### DIFF
--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -355,10 +355,13 @@
 %    |block title alerted|, and |block title example| have an empty
 %    background).
 %
-%    If the |block title| background is empty, we just need to set a rightskip
-%    for a nice ragged-right block title.
+%    If the |block title| background is empty, or the user has explicitly
+%    removed the background from (e.g.) |block title alerted|, we just need to
+%    set a rightskip for a nice ragged-right block title.
 %
 %    \begin{macrocode}
+  \ifbeamercolorempty[bg]{block title#1}{%
+    \begin{beamercolorbox}[rightskip=0pt plus 4em]{block title#1}}{%
   \ifbeamercolorempty[bg]{block title}{%
     \begin{beamercolorbox}[rightskip=0pt plus 4em]{block title#1}%
   }%
@@ -376,7 +379,7 @@
       leftskip=\metropolis@blockadjust,
       rightskip=\dimexpr\metropolis@blockadjust plus 4em\relax
     ]{block title#1}%
-  }%
+  }}%
 %   \end{macrocode}
 %
 %   We can now set the contents of the |block title|. The zero-width but
@@ -397,12 +400,14 @@
 %
 %   \begin{macrocode}
   \nointerlineskip%
-  \ifbeamercolorempty[bg]{block body}{
+  \ifbeamercolorempty[bg]{block body#1}{%
+    \begin{beamercolorbox}[vmode]{block body#1}}{
+  \ifbeamercolorempty[bg]{block body}{%
     \begin{beamercolorbox}[vmode]{block body#1}%
   }{%
     \begin{beamercolorbox}[sep=\metropolis@blocksep, vmode]{block body#1}%
     \vspace{-\metropolis@parskip}
-  }%
+  }}%
       \usebeamerfont{block body#1}%
       \setlength{\parskip}{\metropolis@parskip}%
 }


### PR DESCRIPTION
When I use filled block environments, I do so to structurally separate my main results — theorems, lemmas, questions, etc. — from the discussion surrounding them. I consider examples to be "discussion", so I prefer not to have them filled.

Using ᴍᴇᴛʀᴏᴘᴏʟɪs, the obvious thing to do is

```latex
\metroset{block=fill}
\setbeamercolor{block title example}{bg=}
\setbeamercolor{block body example}{bg=}
```

However, this produces incorrect spacing to the left of the example block:

![screen shot 2016-03-08 at 6 58 21 pm](https://cloud.githubusercontent.com/assets/1131743/13624450/1f7ab90e-e563-11e5-9fa4-2c30d4d55885.png)

This pull requests fixes this bug.

![screen shot 2016-03-08 at 6 57 16 pm](https://cloud.githubusercontent.com/assets/1131743/13624454/27cfe9b2-e563-11e5-849a-515db2a5d9cb.png)

(By the way, @matze, since I now have three pull requests affecting the inner theme open, please let me know if you need me to rebase each against the others. I don't think there should be a problem, since they address different parts of the file, but just in case.)