### PR TITLE
Fix the "Overfull \hbox (0.4pt too wide)" bug when using progress bar.

### DIFF
--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -197,7 +197,7 @@
 %    \begin{macrocode}
 \setbeamertemplate{title separator}{
   \begin{tikzpicture}
-    \draw[fg, fill=fg] (0,0) rectangle (\textwidth, 0.4pt);
+    \fill[fg] (0,0) rectangle (\textwidth, 0.4pt);
   \end{tikzpicture}%
   \par%
 }
@@ -332,8 +332,8 @@
     \textwidth * \ratio{\insertframenumber pt}{\inserttotalframenumber pt}%
   }%
   \begin{tikzpicture}
-    \draw[bg, fill=bg] (0,0) rectangle (\textwidth, 0.4pt);
-    \draw[fg, fill=fg] (0,0) rectangle (\metropolis@progressonsectionpage, 0.4pt);
+    \fill[bg] (0,0) rectangle (\textwidth, 0.4pt);
+    \fill[fg] (0,0) rectangle (\metropolis@progressonsectionpage, 0.4pt);
   \end{tikzpicture}%
 }
 %    \end{macrocode}

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -187,8 +187,8 @@
   }%
   \begin{beamercolorbox}[wd=\paperwidth]{progress bar in head/foot}
     \begin{tikzpicture}
-      \draw[bg, fill=bg] (0,0) rectangle (\paperwidth, 0.4pt);
-      \draw[fg, fill=fg] (0,0) rectangle (\metropolis@progressinheadfoot, 0.4pt);
+      \fill[bg] (0,0) rectangle (\paperwidth, 0.4pt);
+      \fill[fg] (0,0) rectangle (\metropolis@progressinheadfoot, 0.4pt);
     \end{tikzpicture}%
   \end{beamercolorbox}
 }


### PR DESCRIPTION
When using with the options progressbar, there will be a warning like:
> Overfull \hbox (0.4pt too wide) in paragraph at lines ......

this is because that tikz has a default line width of 0.4pt, just fill the rectangle will solve it.