### PR TITLE
Fix empty second line in certain frametitles

### DIFF
--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -168,7 +168,10 @@
       leftskip=\metropolis@frametitle@padding,%
       rightskip=\metropolis@frametitle@padding,%
     ]{frametitle}%
-  \metropolis@frametitlestrut@start\insertframetitle\metropolis@frametitlestrut@end%
+  \metropolis@frametitlestrut@start%
+  \insertframetitle%
+  \nolinebreak%
+  \metropolis@frametitlestrut@end%
   \end{beamercolorbox}%
 }
 %    \end{macrocode}


### PR DESCRIPTION
In #202, @xuhdev reported a problem in certain frametitles. If the width of the frametitle is almost exactly `\linewidth`, then `\metropolis@frametitlestrut@end` could be pushed onto the next line, producing an extra blank line in the frametitle. This PR implements @benjamin-weiss's proposed fix for the problem.