### PR TITLE
Bugfixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ uninstall:
 	@rmdir "$(DOC_DIR)"
 
 clean-cache:
-	@rm -f "$(CACHE_DIR)/*"
+	@rm -rf "$(CACHE_DIR)"
 
 clean-sty:
-	@rm -f "$(PACKAGE_STY)"
+	@rm -f $(PACKAGE_STY)
 
 ctan: $(CTAN_CONTENT) ctan-version
 	@tar --transform "s@\(.*\)@metropolis/\1@" -cf metropolis-$(shell date "+%Y-%m-%d").tar.gz $(CTAN_CONTENT)
@@ -58,15 +58,15 @@ ctan-version:
 $(CACHE_DIR):
 	@mkdir -p $(CACHE_DIR)
 
-$(PACKAGE_STY): $(PACKAGE_SRC) $(INS) | $(CACHE_DIR) clean-cache
+$(PACKAGE_STY): $(PACKAGE_SRC) $(INS) | clean-cache $(CACHE_DIR)
 	@cd $(dir $(INS)) && latex -output-directory=$(CACHE_DIR) $(notdir $(INS))
 	@cp $(addprefix $(CACHE_DIR)/,$(PACKAGE_STY)) .
 
-$(DOC_PDF): $(DOC_SRC) $(PACKAGE_STY) | $(CACHE_DIR) clean-cache
+$(DOC_PDF): $(DOC_SRC) $(PACKAGE_STY) | clean-cache $(CACHE_DIR)
 	@cd $(dir $(DOC_SRC)) && $(COMPILE_TEX) $(notdir $(DOC_SRC))
 	@cp $(CACHE_DIR)/$(notdir $(DOC_PDF)) $(DOC_PDF)
 
-$(DEMO_PDF): $(DEMO_SRC) $(PACKAGE_STY) | $(CACHE_DIR) clean-cache
+$(DEMO_PDF): $(DEMO_SRC) $(PACKAGE_STY) | clean-cache $(CACHE_DIR)
 	@cd $(dir $(DEMO_SRC)) && $(COMPILE_TEX) $(notdir $(DEMO_SRC))
 	@cp $(CACHE_DIR)/$(notdir $(DEMO_PDF)) $(DEMO_PDF)
 

--- a/doc/metropolistheme.dtx
+++ b/doc/metropolistheme.dtx
@@ -630,6 +630,39 @@ on each slide.
 \end{lstlisting}
 
 
+\subsection{Standout frames with labels}
+
+Because the |standout| frame option creates a group to restrict the colour
+change to a single slide, labels defined after calling |standout| will stay
+local to the group. In other words, the following may result in a ``label undefined'' error.
+
+\begin{lstlisting}
+\begin{frame}[standout, label=conclusion]{Conclusion}
+  Awesome slide
+\end{frame}
+\end{lstlisting}
+
+To fix this problem, change the order of the keys in the frame.
+
+\begin{lstlisting}
+\begin{frame}[label=conclusion, standout]{Conclusion}
+    Awesome slide
+\end{frame}
+\end{lstlisting}
+
+This error can be unwittingly triggered if you export your slides from Emacs
+Org mode, which automatically adds labels after frame options. Alex Branham
+\href{https://github.com/matze/mtheme/issues/203}{offers} the following
+solution for Org mode users, using |org-set-property|.
+
+\begin{lstlisting}
+* Start of a frame
+   :PROPERTIES:
+   :BEAMER_opt: label=conclusion,standout
+   :END:
+\end{lstlisting}
+
+
 \section{License}
 
 \themename is licensed under a

--- a/doc/metropolistheme.dtx
+++ b/doc/metropolistheme.dtx
@@ -663,6 +663,16 @@ solution for Org mode users, using |org-set-property|.
 \end{lstlisting}
 
 
+\subsection{Standout frames with Pandoc}
+
+It is not currently possible to create standout frames if you create your
+presentation with Pandoc. This is because Pandoc only supports a specific list
+of frame attributes --- namely, |allowdisplaybreaks|, |allowframebreaks|, |b|,
+|c|, |t|, |environment|, |label|, |plain|, and |shrink|. In other words,
+Pandoc will ignore the attribute |{.standout}| instead of adding the option to
+the frame.
+
+
 \section{License}
 
 \themename is licensed under a

--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -369,6 +369,12 @@
     \metropolis@sectiontitleformat{#1}}}}
   {}
   {\PackageError{beamerfontthememetropolis}{Patching section title failed}}
+\patchcmd{\beamer@subsection}
+  {\def\insertsubsectionhead{\hyperlink{Navigation\the\c@page}{#1}}}
+  {\def\insertsubsectionhead{\hyperlink{Navigation\the\c@page}{%
+    \metropolis@sectiontitleformat{#1}}}}
+  {}
+  {\PackageError{beamerfontthememetropolis}{Patching section title failed}}
 %    \end{macrocode}
 %
 % Similarly, to make the |\MakeLowercase| and |\MakeUppercase| macros work in

--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -65,7 +65,7 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{sectionpage}
+% \begin{macro}{subsectionpage}
 %    Optionally add a slide marking the beginning of each subsection.
 %    \begin{macrocode}
 \pgfkeys{
@@ -251,10 +251,10 @@
     \usebeamercolor[fg]{section title}
     \usebeamerfont{section title}
     \insertsectionhead\par
-    \ifx\insertsubsection\@empty\else
+    \ifx\insertsubsectionhead\@empty\else
       \usebeamercolor[fg]{subsection title}
       \usebeamerfont{subsection title}
-      \insertsubsection
+      \insertsubsectionhead
     \fi
   \end{center}
 }
@@ -267,10 +267,10 @@
     \insertsectionhead\\[-1ex]
     \usebeamertemplate*{progress bar in section page}
     \par
-    \ifx\insertsubsection\@empty\else%
+    \ifx\insertsubsectionhead\@empty\else%
       \usebeamercolor[fg]{subsection title}%
       \usebeamerfont{subsection title}%
-      \insertsubsection
+      \insertsubsectionhead
     \fi
   \end{minipage}
   \par


### PR DESCRIPTION
This pull request resolves a few of the currently open issues:

- Subsection titles are now formatted with `\metropolis@sectiontitleformat`, so `titleformat section=allsmallcaps` also affects subsection slides (see #212).
- The known issues reported in #203 and #205 are added to the documentation.
- A previously unreported bug with `make clean` is fixed.