### PR TITLE
Fix a typo in documentation

### DIFF
--- a/doc/metropolistheme.dtx
+++ b/doc/metropolistheme.dtx
@@ -400,7 +400,7 @@ The list of options is structured as shown in the following example.
 
 \DescribeMacro{titleformat title}
 \DescribeMacro{titleformat subtitle}
-\DescribeMacro{titeformat section}
+\DescribeMacro{titleformat section}
 \DescribeOption{titleformat frame}%
                {regular, smallcaps, allsmallcaps, allcaps}%
                {regular}{


### PR DESCRIPTION
This PR fixes a typo I found when I copy-pasted from the documentation and got an unknown key error.

P.S. Thanks for creating this fantastic theme!