### PR TITLE
Fix make uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ install: $(PACKAGE_STY) $(DOC_PDF)
 	@cp $(DOC_PDF) $(DOC_DIR)
 
 uninstall:
-	@rm -f "$(addprefix $(INSTALL_DIR)/, $(PACKAGE_STY))"
+	@rm -f $(addprefix $(INSTALL_DIR)/, $(PACKAGE_STY))
 	@rmdir "$(INSTALL_DIR)"
 	@rm -f "$(DOC_DIR)/$(notdir $(DOC_PDF))"
 	@rmdir "$(DOC_DIR)"


### PR DESCRIPTION
The double quotes in make uninstall prevented `rm` from working properly at least on OS X
