### PR TITLE
fixes #237: Allow to define the width of the progress bar

### DIFF
--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -196,9 +196,11 @@
 %   Template to set the title graphic in a zero-height box. (It won't
 %   change the position of other elements.)
 %    \begin{macrocode}
+\newlength{\metropolis@titleseparator@linewidth}
+\setlength{\metropolis@titleseparator@linewidth}{0.4pt}
 \setbeamertemplate{title separator}{
   \begin{tikzpicture}
-    \fill[fg] (0,0) rectangle (\textwidth, 0.4pt);
+    \fill[fg] (0,0) rectangle (\textwidth, \metropolis@titleseparator@linewidth);
   \end{tikzpicture}%
   \par%
 }
@@ -328,13 +330,15 @@
 %
 %    \begin{macrocode}
 \newlength{\metropolis@progressonsectionpage}
+\newlength{\metropolis@progressonsectionpage@linewidth}
+\setlength{\metropolis@progressonsectionpage@linewidth}{0.4pt}
 \setbeamertemplate{progress bar in section page}{
   \setlength{\metropolis@progressonsectionpage}{%
     \textwidth * \ratio{\insertframenumber pt}{\inserttotalframenumber pt}%
   }%
   \begin{tikzpicture}
-    \fill[bg] (0,0) rectangle (\textwidth, 0.4pt);
-    \fill[fg] (0,0) rectangle (\metropolis@progressonsectionpage, 0.4pt);
+    \fill[bg] (0,0) rectangle (\textwidth, \metropolis@progressonsectionpage@linewidth);
+    \fill[fg] (0,0) rectangle (\metropolis@progressonsectionpage, \metropolis@progressonsectionpage@linewidth);
   \end{tikzpicture}%
 }
 %    \end{macrocode}

--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -187,6 +187,8 @@
 %    template |progress bar in section page|.
 %    \begin{macrocode}
 \newlength{\metropolis@progressinheadfoot}
+\newlength{\metropolis@progressinheadfoot@linewidth}
+\setlength{\metropolis@progressinheadfoot@linewidth}{0.4pt}
 \setbeamertemplate{progress bar in head/foot}{
   \nointerlineskip
   \setlength{\metropolis@progressinheadfoot}{%
@@ -194,8 +196,8 @@
   }%
   \begin{beamercolorbox}[wd=\paperwidth]{progress bar in head/foot}
     \begin{tikzpicture}
-      \fill[bg] (0,0) rectangle (\paperwidth, 0.4pt);
-      \fill[fg] (0,0) rectangle (\metropolis@progressinheadfoot, 0.4pt);
+      \fill[bg] (0,0) rectangle (\paperwidth, \metropolis@progressinheadfoot@linewidth);
+      \fill[fg] (0,0) rectangle (\metropolis@progressinheadfoot, \metropolis@progressinheadfoot@linewidth);
     \end{tikzpicture}%
   \end{beamercolorbox}
 }


### PR DESCRIPTION
I don’t think we should provide an option to solve this. So this PR only introduces internal variables for the line width of the progress bar and the title separator, namely:

- `\metropolis@titleseparator@linewidth`
- `\metropolis@progressonsectionpage@linewidth`
- `\metropolis@progressinheadfoot@linewidth`