### PR TITLE
Fix fontspec option clash

### DIFF
--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -45,7 +45,11 @@
 %
 %    \begin{macrocode}
 \ifboolexpr{bool {xetex} or bool {luatex}}{
-  \RequirePackage[no-math]{fontspec}
+  \@ifpackageloaded{fontspec}{
+    \PassOptionsToPackage{no-math}{fontspec}
+  }{
+    \RequirePackage[no-math]{fontspec}
+  }
 %    \end{macrocode}
 %
 % \begin{macro}{\checkfont}


### PR DESCRIPTION
I stumbled on #239 myself. I could fix it by only loading `fontspec` if it isn’t loaded yet. This solutions has no negative effects from my point of view, but fixes option clashes in some cases.

Note: I was not able to test if the `no-math` option is still passed in correctly, as I can’t produce a case in which it’s needed. 