### PR TITLE
Drop braces in input line

### DIFF
--- a/source/beamerthememetropolis.ins
+++ b/source/beamerthememetropolis.ins
@@ -10,7 +10,7 @@
 %% International License (https://creativecommons.org/licenses/by-sa/4.0/).
 %% ---------------------------------------------------------------------------
 
-\input{docstrip.tex}
+\input docstrip.tex %
 \keepsilent
 \askforoverwritefalse
 \usedir{tex/latex/mtheme}


### PR DESCRIPTION
It's normal to be able to DocStrip using TeX, not LaTeX: the 'classic' engines (everything other than LuaTeX) don't accept braces at the primitive level.