### PR TITLE
Add missing arguments for \PackageError

### DIFF
--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -356,29 +356,29 @@
   {\def\inserttitle{#2}}%
   {\def\inserttitle{\metropolis@titleformat{#2}}}%
   {}%
-  {\PackageError{beamerfontthememetropolis}{Patching title failed}}
+  {\PackageError{beamerfontthememetropolis}{Patching title failed}\@ehc}
 \patchcmd{\beamer@subtitle}%
   {\def\insertsubtitle{#2}}%
   {\def\insertsubtitle{\metropolis@subtitleformat{#2}}}%
   {}%
-  {\PackageError{beamerfontthememetropolis}{Patching subtitle failed}}
+  {\PackageError{beamerfontthememetropolis}{Patching subtitle failed}\@ehc}
 \patchcmd{\sectionentry}
   {\def\insertsectionhead{#2}}
   {\def\insertsectionhead{\metropolis@sectiontitleformat{#2}}}
   {}
-  {\PackageError{beamerfontthememetropolis}{Patching section title failed}}
+  {\PackageError{beamerfontthememetropolis}{Patching section title failed}\@ehc}
 \patchcmd{\beamer@section}
   {\def\insertsectionhead{\hyperlink{Navigation\the\c@page}{#1}}}
   {\def\insertsectionhead{\hyperlink{Navigation\the\c@page}{%
     \metropolis@sectiontitleformat{#1}}}}
   {}
-  {\PackageError{beamerfontthememetropolis}{Patching section title failed}}
+  {\PackageError{beamerfontthememetropolis}{Patching section title failed}\@ehc}
 \patchcmd{\beamer@subsection}
   {\def\insertsubsectionhead{\hyperlink{Navigation\the\c@page}{#1}}}
   {\def\insertsubsectionhead{\hyperlink{Navigation\the\c@page}{%
     \metropolis@sectiontitleformat{#1}}}}
   {}
-  {\PackageError{beamerfontthememetropolis}{Patching section title failed}}
+  {\PackageError{beamerfontthememetropolis}{Patching section title failed}\@ehc}
 %    \end{macrocode}
 %
 % Similarly, to make the |\MakeLowercase| and |\MakeUppercase| macros work in
@@ -400,7 +400,7 @@
     \gdef\beamer@shortframetitle{#1}%
     }}
   {}
-  {\PackageError{beamerfontthememetropolis}{Patching frame title failed}}
+  {\PackageError{beamerfontthememetropolis}{Patching frame title failed}\@ehc}
 %    \end{macrocode}
 %
 %


### PR DESCRIPTION
The command needs three arguments: \@ehc is the 'Press Enter to
continue" generic advice.