### PR TITLE
Simplify a patch

### DIFF
--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -406,13 +406,13 @@
 %
 %    \begin{macrocode}
 \patchcmd{\beamer@@frametitle}
-  {\beamer@ifempty{#2}{}{%
+  {{%
       \gdef\insertframetitle{{#2\ifnum\beamer@autobreakcount>0\relax{}\space%
       \usebeamertemplate*{frametitle continuation}\fi}}%
     \gdef\beamer@frametitle{#2}%
     \gdef\beamer@shortframetitle{#1}%
     }}
-  {\beamer@ifempty{#2}{}{%
+  {{%
       \gdef\insertframetitle{{\metropolis@frametitleformat{#2}\ifnum%
       \beamer@autobreakcount>0\relax{}\space%
       \usebeamertemplate*{frametitle continuation}\fi}}%


### PR DESCRIPTION
This avoids looking for an internal command that will be removed in a future update. I plan to drop `\beamer@ifempty` in favour of `\ifblank` from `etoolbox`: a change here makes that 'transparent'.