### PR TITLE
fix \ProvidesPackage{} for highcontrast theme

### DIFF
--- a/source/beamercolorthememetropolis-highcontrast.dtx
+++ b/source/beamercolorthememetropolis-highcontrast.dtx
@@ -12,7 +12,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthememetropolis-minimal}[2016/03/14 Metropolis color theme]
+\ProvidesPackage{beamercolorthememetropolis-highcontrast}[2016/03/14 Metropolis color theme]
 %</package>
 % \fi
 % \CheckSum{0}


### PR DESCRIPTION
Removes warning:

LaTeX Warning: You have requested package `beamercolorthememetropolis-highcontrast',
               but the package provides `beamercolorthememetropolis-minimal'.

when used as in

\usetheme{metropolis}
\usecolortheme{metropolis-highcontrast}
