### PR TITLE
Adding Travis-CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+sudo: required
+dist: trusty
+before_install:
+- sudo apt-get -qq update && sudo apt-get install -y --no-install-recommends texlive-fonts-recommended
+  texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended
+
+script:
+- make sty
+
+before_deploy:
+- zip metropolis.zip *.sty
+- tar -czf metropolis.tar.gz *.sty
+deploy:
+  provider: releases
+  api_key:
+    secure: evcPKEWOizwYAKE5hj4lW2TLJKdP+sl51fniYInR9NwpcGKE8+N4MIWdjZWzW775s87ReSoNxBkE9ipxc5+ViZvmQAbFnZ/j1DfPJlJ8Fy5w0BOPZ8Ui9o405l4Tt3H/wyi25cGOwAYgeXyjOLC5777JAc9znSoXdJbkqC6kSsqEJ8meFo9oumyRmuJ7AWh9dFTw8ZgrEuKoOOyx7tTaiTzv1l/meNJ1Wq0N5RISvWqTQY6Ra3gOE5cJFa9N3Oo7mPtwmBaeac2H+HGeE5iCvLJtn9mt1hWVqo1vos3M1r6ZrQnaoY3SnqNjuMcWwUbqer6taJ6UKvhqs3pHUfifNlr6tPqiTzqDKHugn9afn5swZiViVXc4RuBbYwLQLJE+wLe4DAkA6RyCXvYvlpjxtuw/71uKSI08K962wskcADHVWVH5IPtvL7Y1EVzHqdJkYWcZo/QDEfodL8BZOqXbdYdhiB2nFrjELF6a1EHNCxMKJFZV87xNW1xspdhKetrTx0OM7QhqSx8E2OGOYENqM2YEG4p9MyU1QPv+VomUXhI2kPMsIK1IFqEZUxdrHjwTx3zN4zkfvKM9phClNRMIxEe/OXSEbfKAKe7mrRDconpOx9TBerSO8oNqsH833vZoI8rj8moZttQkUMXYMIS+YM1MYx3xi4pCrBRx/DLaNhc=
+  file: 
+    - metropolis.zip
+    - metropolis.tar.gz
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
Adding a Travis-CI Integration for automatic generation of `sty` files and upload to GitHub releases.

Steps to adapt:

1. Log into [Travis-CI](https://travis-ci.org/) with your GitHub account.
2. Enable your mtheme repo in Travis-CI.
3. Create a [OAuth Token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) for your GitHub account.
4. Add the Token to the Travis config file by [installing the Travis CLI client](https://blog.travis-ci.com/2013-01-14-new-client/) and running `travis encrypt "GITHUB TOKEN" --add deploy.password`.
5. Commit the change and push.
6. Create the v1.0.0 Tag and push the tags: `git tag v1.0.0 && git push --tags`

Now a new artifact is released at every tag.