### PR TITLE
Updated Fira font paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ docker-run: docker-build
 	docker run --rm=true --name $(DOCKER_CONTAINER) -i -t -v `pwd`:/data $(DOCKER_IMAGE) make
 
 docker-build:
-	docker build -t $(DOCKER_IMAGE) .
+	docker build -t $(DOCKER_IMAGE) docker
 
 docker-rm:
 	docker rm $(DOCKER_CONTAINER)

--- a/docker/getFiraFont.sh
+++ b/docker/getFiraFont.sh
@@ -5,16 +5,26 @@
 cd /tmp
 
 # install unzip just in case the user doesn't already have it.
-sudo apt-get install unzip -y
-wget "http://www.carrois.com/downloads/fira_4_1/FiraFonts4106.zip"
-wget "http://www.carrois.com/downloads/fira_mono_3_2/FiraMonoFonts3206.zip"
+apt-get install unzip -y
 
-unzip FiraFonts4106.zip
-unzip FiraMonoFonts3206.zip
+# Fonts also available at: https://github.com/bBoxType/FiraSans
+wget "https://bboxtype.com/downloads/Fira/Download_Folder_FiraSans_4301.zip"
+wget "https://bboxtype.com/downloads/Fira/Fira_Mono_3_2.zip"
+
+unzip Download_Folder_FiraSans_4301.zip
+unzip Fira_Mono_3_2.zip
 
 sudo mkdir -p /usr/share/fonts/truetype/FiraSans
 sudo mkdir -p /usr/share/fonts/opentype/FiraSans
-sudo cp Fira*/WEB/TTF/*.ttf /usr/share/fonts/truetype/FiraSans/
-sudo cp Fira*/OTF/Fira* /usr/share/fonts/opentype/FiraSans/
 
-sudo fc-cache -fv
+cp Download_Folder_FiraSans_4301/Fonts/Fira_Sans_TTF_4301/*/*/*.ttf \
+	/usr/share/fonts/truetype/FiraSans/
+cp Download_Folder_FiraSans_4301/Fonts/Fira_Sans_OTF_4301/*/*/*.otf \
+	/usr/share/fonts/opentype/FiraSans/
+cp Fira_Mono_3_2/Fonts/FiraMono_WEB_32/*.ttf /usr/share/fonts/truetype/FiraSans
+cp Fira_Mono_3_2/Fonts/FiraMono_OTF_32/*.otf /usr/share/fonts/truetype/FiraSans
+
+rm Download_Folder_FiraSans_4301.zip Fira_Mono_3_2.zip
+rm -rf Download_Folder_FiraSans_4301 Fira_Mono_3_2
+
+fc-cache -fv


### PR DESCRIPTION
Fira fonts have moved to https://bboxtype.com/typefaces/FiraSans/ and https://github.com/bBoxType/FiraSans.
This updates the getFiraFont.sh script to download the files from the new location.
Also removed calls to 'sudo', which is not installed and is unnecessary for the docker image.
Fixed docker build command in Makefile.