### PR TITLE
Restore theme within frame, making standout slides work with ignorenonframetext

### DIFF
--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -569,11 +569,11 @@
 %    in order to restore the colours and fonts for the rest of the
 %    presentation. Unfortunately, we cannot use \AfterEndEnvironment{frame} for
 %    this (see \url{http://tex.stackexchange.com/questions/226319/}).
-%    Instead, we add the |\endgroup| to |\beamer@reseteecodes|, which is run
+%    Instead, we prepend the |\endgroup| to |\beamer@reseteecodes|, which is run
 %    exactly once at the end of each slide.
 %
 %    \begin{macrocode}
-  \apptocmd{\beamer@reseteecodes}{%
+  \pretocmd{\beamer@reseteecodes}{%
     \ifbool{metropolis@standout}{
       \endgroup
       \boolfalse{metropolis@standout}


### PR DESCRIPTION
Should solve issue #335.

State is well restored even with `ignorenonframetext`.

~~Notes are still impacted though.~~ Not anymore, see PR #337.

![standout-ignorenonframetext-fixup](https://user-images.githubusercontent.com/1449319/43050544-bf9ecc34-8e0a-11e8-8861-4f27b1947b63.png)