### PR TITLE
Restrict standout font and alignment to inner content

### DIFF
--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -536,7 +536,7 @@
 %     Optional arguments to Beamer's frames are implemented using
 %     |\define@key| from the |keyval| package, which will execute code when the
 %     defined option is called. For the |standout| option, we begin a group,
-%     change the colors and fonts, and set a \centering alignment.
+%     change the colors and set frame options.
 %
 %    \begin{macrocode}
 \providebool{metropolis@standout}
@@ -559,9 +559,7 @@
     \setbeamercolor{local structure}{
       fg=palette primary.fg
     }
-    \centering
     \usebeamercolor[fg]{palette primary}
-    \usebeamerfont{standout}
 }
 %    \end{macrocode}
 %
@@ -579,6 +577,19 @@
       \boolfalse{metropolis@standout}
     }{}
   }{}{}
+%    \end{macrocode}
+%
+%    We set the fonts and the \centering alignment on the inner content,
+%    in such a way that the speaker's note layout isn't affected by the custom
+%    formatting.
+%
+%    \begin{macrocode}
+  \AtBeginEnvironment{beamer@frameslide}{
+    \ifbool{metropolis@standout}{
+      \centering
+      \usebeamerfont{standout}
+    }{}
+  }
 %    \end{macrocode}
 % \end{macro}
 %


### PR DESCRIPTION
Solves issue #334.

![standout-notes-fixup](https://user-images.githubusercontent.com/1449319/43051301-1a0962c6-8e18-11e8-9853-381554fe8c01.png)