### PR TITLE
`\appendix` resets templates to `plain` mode

### DIFF
--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -205,25 +205,6 @@
 }
 %    \end{macrocode}
 % \end{macro}
-%
-%
-%
-% \begin{macro}{appendix}
-%    Removes page numbering and per-slide progress bars when |\appendix| is
-%    called. This makes it easier to include additional ``backup slides'' at
-%    the end of the presentation, especially in conjunction with the package
-%    |appendixnumberbeamer|.
-%    \begin{macrocode}
-\AtBeginDocument{%
-  \apptocmd{\appendix}{%
-    \pgfkeys{%
-      /metropolis/outer/.cd,
-      numbering=none,
-      progressbar=none}
-    }{}{}
-}
-%    \end{macrocode}
-% \end{macro}
 % \subsubsection{Process package options}
 %
 %    \begin{macrocode}


### PR DESCRIPTION
The metropolis `\appendix` command is invoking
```
\pgfkeys{%
      /metropolis/outer/.cd,
      numbering=none,
      progressbar=none}
```
this will invoke
```
\setbeamertemplate{frame numbering}[none]
\setbeamertemplate{headline}[plain]
\setbeamertemplate{frametitle}[plain]
\setbeamertemplate{footline}[plain]
```
IMHO, appendix pages *should* be numbered, and have headlines, frametitles, footlines. But in particular, this kills any modifications done to these templates. My workaround is to kill the pgfkey `.code` statements before the appendix, so that metropolis doesn't modify them.

If a user wants to hide numbers, he can simply do
```
\setbeamertemplate{frame numbering}[none]
\appendix
```
similar, if he indeed wants the appendix frames to be plain. Resetting them should not be the default.

For the progressbar, IMHO a proper fix for #274 is better than this hack to hide them.