### PR TITLE
Disable hyphenation in frametitles

### DIFF
--- a/source/beamerouterthememetropolis.dtx
+++ b/source/beamerouterthememetropolis.dtx
@@ -166,7 +166,7 @@
       wd=\paperwidth,%
       sep=0pt,%
       leftskip=\metropolis@frametitle@padding,%
-      rightskip=\metropolis@frametitle@padding,%
+      rightskip=\the\glueexpr \metropolis@frametitle@padding plus 1fill\relax,%
     ]{frametitle}%
   \metropolis@frametitlestrut@start%
   \insertframetitle%


### PR DESCRIPTION
I noticed that long frametitles are hyphenated and got this solution from Ulrike Fischer on Stack Exchange: https://tex.stackexchange.com/questions/591505/disable-hyphenation-in-metropolis-frametitles/591523#591523