### PR TITLE
Adapting patch to new beamer code

### DIFF
--- a/source/beamerfontthememetropolis.dtx
+++ b/source/beamerfontthememetropolis.dtx
@@ -418,19 +418,22 @@
 %
 %    \begin{macrocode}
 \patchcmd{\beamer@@frametitle}
-  {{%
-      \gdef\insertframetitle{{#2\ifnum\beamer@autobreakcount>0\relax{}\space%
-      \usebeamertemplate*{frametitle continuation}\fi}}%
-    \gdef\beamer@frametitle{#2}%
-    \gdef\beamer@shortframetitle{#1}%
-    }}
-  {{%
-      \gdef\insertframetitle{{\metropolis@frametitleformat{#2}\ifnum%
-      \beamer@autobreakcount>0\relax{}\space%
-      \usebeamertemplate*{frametitle continuation}\fi}}%
-    \gdef\beamer@frametitle{#2}%
-    \gdef\beamer@shortframetitle{#1}%
-    }}
+  {\gdef\insertframetitle{{%
+      #2%
+      \ifnum\beamer@autobreakcount>0
+        \relax{}\space%
+        \beamer@insertframetitlecontinuation%
+      \fi%
+    }}%
+  }
+  {\gdef\insertframetitle{{%
+      \metropolis@frametitleformat{#2}%
+      \ifnum\beamer@autobreakcount>0
+        \relax{}\space%
+        \beamer@insertframetitlecontinuation%
+      \fi%
+    }}%
+  }
   {}
   {\PackageError{beamerfontthememetropolis}{Patching frame title failed}\@ehc}
 %    \end{macrocode}


### PR DESCRIPTION
Changes to the beamer code break one of the patches of the metropolis theme. This PR updates the patches to be compatible with the new beamer code.

To prevent completely breaking the metropolis theme, beamer currently has some first aid hack in place https://github.com/josephwright/beamer/commit/4bed882a250335d7f89bb00393f4509d57246a5b#diff-30cff327f07d535e6f0d4d98327cbee2f4c59563c3ae2136758c5343ec60a9b6

See for details https://github.com/josephwright/beamer/issues/802